### PR TITLE
fix(payments): we can update a status in payments v3

### DIFF
--- a/cmd/payments/transferinitiation/update_status.go
+++ b/cmd/payments/transferinitiation/update_status.go
@@ -60,7 +60,7 @@ func (c *UpdateStatusController) Run(cmd *cobra.Command, args []string) (fctl.Re
 		return nil, err
 	}
 
-	if c.PaymentsVersion < versions.V1 || c.PaymentsVersion >= versions.V3 {
+	if c.PaymentsVersion < versions.V1 {
 		return nil, fmt.Errorf("transfer initiation updates are only supported in == v2.0.0")
 	}
 

--- a/cmd/payments/transferinitiation/update_status.go
+++ b/cmd/payments/transferinitiation/update_status.go
@@ -61,7 +61,7 @@ func (c *UpdateStatusController) Run(cmd *cobra.Command, args []string) (fctl.Re
 	}
 
 	if c.PaymentsVersion < versions.V1 {
-		return nil, fmt.Errorf("transfer initiation updates are only supported in == v2.0.0")
+		return nil, fmt.Errorf("transfer initiation updates are only supported in >= v2.0.0")
 	}
 
 	if !fctl.CheckStackApprobation(cmd, store.Stack(), "You are about to update the status of the transfer initiation '%s' to '%s'", args[0], args[1]) {


### PR DESCRIPTION
Since we're still supported the v2 api, the update status for transfer init should still be working even if we the payments service is in v3.x