### PR TITLE
feat: Add default stack to profile output

### DIFF
--- a/cmd/profiles/show.go
+++ b/cmd/profiles/show.go
@@ -10,6 +10,7 @@ import (
 type ProfilesShowStore struct {
 	MembershipURI       string `json:"membershipUri"`
 	DefaultOrganization string `json:"defaultOrganization"`
+	DefaultStack        string `json:"defaultStack"`
 }
 type ProfilesShowController struct {
 	store *ProfilesShowStore
@@ -21,6 +22,7 @@ func NewDefaultProfilesShowStore() *ProfilesShowStore {
 	return &ProfilesShowStore{
 		MembershipURI:       "",
 		DefaultOrganization: "",
+		DefaultStack:        "",
 	}
 }
 
@@ -48,6 +50,7 @@ func (c *ProfilesShowController) Run(cmd *cobra.Command, args []string) (fctl.Re
 
 	c.store.DefaultOrganization = p.GetDefaultOrganization()
 	c.store.MembershipURI = p.GetMembershipURI()
+	c.store.DefaultStack = p.GetDefaultStack()
 
 	return c, nil
 }
@@ -57,6 +60,7 @@ func (c *ProfilesShowController) Render(cmd *cobra.Command, args []string) error
 	tableData := pterm.TableData{}
 	tableData = append(tableData, []string{pterm.LightCyan("Membership URI"), c.store.MembershipURI})
 	tableData = append(tableData, []string{pterm.LightCyan("Default organization"), c.store.DefaultOrganization})
+	tableData = append(tableData, []string{pterm.LightCyan("Default stack"), c.store.DefaultStack})
 	return pterm.DefaultTable.
 		WithWriter(cmd.OutOrStdout()).
 		WithData(tableData).


### PR DESCRIPTION
Add the default stack to the `fctl profiles show <name>` command output to provide complete profile information.

---
[Slack Thread](https://numary.slack.com/archives/C041YKFBK7U/p1758124238278909?thread_ts=1758124238.278909&cid=C041YKFBK7U)

<a href="https://cursor.com/background-agent?bcId=bc-7ee1d06c-b9b6-4948-bff8-57f977a286cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ee1d06c-b9b6-4948-bff8-57f977a286cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

