### PR TITLE
chore: Update envrc to load env if exists

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
 use flake --impure
-dotenv
+dotenv_if_exists ".env"


### PR DESCRIPTION
Replace `dotenv` with `dotenv_if_exists ".env"` in `.envrc` to load the `.env` file only if it exists, preventing errors when it's not present.

---
[Slack Thread](https://numary.slack.com/archives/C041YKFBK7U/p1758204330988959?thread_ts=1758204330.988959&cid=C041YKFBK7U)

<a href="https://cursor.com/background-agent?bcId=bc-4ccdfd85-c723-4210-9e53-debb62897e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ccdfd85-c723-4210-9e53-debb62897e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

