### PR TITLE
Update payment connector command list

### DIFF
--- a/cmd/payments/connectors/configs/getconfig.go
+++ b/cmd/payments/connectors/configs/getconfig.go
@@ -179,6 +179,10 @@ func (c *PaymentsGetConfigController) Render(cmd *cobra.Command, args []string) 
 		err = views.DisplayAtlarConfig(cmd, c.store.ConnectorConfig)
 	case internal.AdyenConnector:
 		err = views.DisplayAdyenConfig(cmd, c.store.ConnectorConfig)
+	case internal.QontoConnector:
+		err = views.DisplayQontoConfig(cmd, c.store.ConnectorConfig)
+	case internal.ColumnConnector:
+		err = views.DisplayColumnConfig(cmd, c.store.ConnectorConfig)
 	default:
 		pterm.Error.WithWriter(cmd.OutOrStderr()).Printfln("Connection unknown.")
 	}

--- a/cmd/payments/connectors/configs/root.go
+++ b/cmd/payments/connectors/configs/root.go
@@ -1,6 +1,9 @@
 package configs
 
 import (
+	"fmt"
+
+	"github.com/formancehq/fctl/cmd/payments/connectors/internal"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/spf13/cobra"
 )
@@ -8,7 +11,7 @@ import (
 func NewUpdateConfigCommands() *cobra.Command {
 	return fctl.NewCommand("update-config",
 		fctl.WithAliases("uc"),
-		fctl.WithShortDescription("Update the config of a connector"),
+		fctl.WithShortDescription(fmt.Sprintf("Update the config of a connector (Connectors available: %v)", internal.AllConnectors)),
 		fctl.WithChildCommands(
 			newUpdateAdyenCommand(),
 			newUpdateAtlarCommand(),

--- a/cmd/payments/connectors/install/root.go
+++ b/cmd/payments/connectors/install/root.go
@@ -1,6 +1,9 @@
 package install
 
 import (
+	"fmt"
+
+	"github.com/formancehq/fctl/cmd/payments/connectors/internal"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/spf13/cobra"
 )
@@ -8,7 +11,7 @@ import (
 func NewInstallCommand() *cobra.Command {
 	return fctl.NewCommand("install",
 		fctl.WithAliases("i"),
-		fctl.WithShortDescription("Install a connector"),
+		fctl.WithShortDescription(fmt.Sprintf("Install a connector (Connectors available: %v)", internal.AllConnectors)),
 		fctl.WithChildCommands(
 			NewAdyenCommand(),
 			NewStripeCommand(),

--- a/cmd/payments/connectors/views/column.go
+++ b/cmd/payments/connectors/views/column.go
@@ -1,0 +1,19 @@
+package views
+
+import (
+	"encoding/json"
+
+	"github.com/formancehq/formance-sdk-go/v3/pkg/models/shared"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+func DisplayColumnConfig(cmd *cobra.Command, connectorConfig *shared.ConnectorConfigResponse) error {
+	// Display raw JSON since SDK might not have ColumnConfig type yet
+	jsonData, err := json.MarshalIndent(connectorConfig.Data, "", "  ")
+	if err != nil {
+		return err
+	}
+	pterm.DefaultBox.WithWriter(cmd.OutOrStdout()).WithTitle("Column Configuration").Println(string(jsonData))
+	return nil
+}

--- a/cmd/payments/connectors/views/qonto.go
+++ b/cmd/payments/connectors/views/qonto.go
@@ -1,0 +1,19 @@
+package views
+
+import (
+	"encoding/json"
+
+	"github.com/formancehq/formance-sdk-go/v3/pkg/models/shared"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+func DisplayQontoConfig(cmd *cobra.Command, connectorConfig *shared.ConnectorConfigResponse) error {
+	// Display raw JSON since SDK might not have QontoConfig type yet
+	jsonData, err := json.MarshalIndent(connectorConfig.Data, "", "  ")
+	if err != nil {
+		return err
+	}
+	pterm.DefaultBox.WithWriter(cmd.OutOrStdout()).WithTitle("Qonto Configuration").Println(string(jsonData))
+	return nil
+}


### PR DESCRIPTION
List Qonto and Column connectors in `fctl payments connectors install` and `update-config` help texts and enable their configuration display to improve discoverability.

---
[Slack Thread](https://numary.slack.com/archives/C041YKFBK7U/p1760604084982429?thread_ts=1760604084.982429&cid=C041YKFBK7U)

<a href="https://cursor.com/background-agent?bcId=bc-5985a8ee-0cdd-439f-ae86-5b3b47fb2127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5985a8ee-0cdd-439f-ae86-5b3b47fb2127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

