### PR TITLE
feat: bind environment variable to flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,7 +105,9 @@ func Execute() {
 		}
 	}()
 	ctx, _ := signal.NotifyContext(context.TODO(), os.Interrupt)
+
 	cmd := NewRootCommand()
+	service.BindEnvToCommand(cmd)
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		switch {
 		case errors.Is(err, fctl.ErrMissingApproval):


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bind environment variables to CLI flags so the CLI can be configured via env, making CI and container setups easier.

- **New Features**
  - Added service.BindEnvToCommand to map environment variables to flags on the root command.
  - Imported go-libs v3 service package to enable binding.

<sup>Written for commit f37ba1c74c4d5d43cbfa6533cb8431daeb7aac44. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



