### PR TITLE
chore(speakeasy): Sync speakeasy version with nix's

### DIFF
--- a/internal/deployserverclient/.speakeasy/gen.lock
+++ b/internal/deployserverclient/.speakeasy/gen.lock
@@ -3,14 +3,14 @@ id: 12df0dd4-09cf-49f5-8116-53c77b28ba01
 management:
   docChecksum: c7e98d8b5bc9be6f81f0eeed1f3a5870
   docVersion: 0.1.0
-  speakeasyVersion: 1.697.5
-  generationVersion: 2.799.0
+  speakeasyVersion: 1.690.0
+  generationVersion: 2.797.1
   releaseVersion: 0.0.1
   configChecksum: a487585e540fe4bf00ef54c113512a47
 persistentEdits:
-  generation_id: 53ae6319-3673-48bc-91a0-19998c8752c0
-  pristine_commit_hash: 93fed012f60be2d5afa1998b7cd2c682b0671247
-  pristine_tree_hash: a2046a687940fe92cb07819fbbd4b279dff590f0
+  generation_id: ced549cf-9bcb-45dd-a8d6-a588dbbd8aeb
+  pristine_commit_hash: cce09a3828ce214b6f67a9b0c3aaf851aa4eb87d
+  pristine_tree_hash: e0847cfc459fe58f38ece7aee132617bc5d9f508
 features:
   go:
     acceptHeaders: 2.81.2
@@ -53,8 +53,8 @@ trackedFiles:
     pristine_git_object: 6923f88297e52b644b172b3c7e22ed915848c0e2
   deployserver.go:
     id: 4e88cb1c88d3
-    last_write_checksum: sha1:4fb641205e6b1550787fe49157689db5da133f8a
-    pristine_git_object: 45e137b1e7b067e343b1242acadb4d2770251508
+    last_write_checksum: sha1:43a6469a43d76d2485002bb45983891face64c63
+    pristine_git_object: 279687f06ff05c52a388c2a739b096e3958055b6
   docs/models/components/app.md:
     id: a31b0d7743a7
     last_write_checksum: sha1:223551b0228ef49a4fbc16dce5403b407354741a

--- a/internal/deployserverclient/.speakeasy/workflow.lock
+++ b/internal/deployserverclient/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.697.5
+speakeasyVersion: 1.690.0
 sources:
     Terraform HCP Proxy API:
         sourceNamespace: terraform-hcp-proxy-api
@@ -15,7 +15,7 @@ targets:
         sourceBlobDigest: sha256:4e4bf80a183fb2ae17d4ae27d2a6de867db0654fe28483c80ec25e9530e3a967
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: latest
+    speakeasyVersion: 1.690.0
     sources:
         Terraform HCP Proxy API:
             inputs:

--- a/internal/deployserverclient/.speakeasy/workflow.yaml
+++ b/internal/deployserverclient/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: latest
+speakeasyVersion: 1.690.0 # Should be synced with flake.nix speakeasy version.
 sources:
     Terraform HCP Proxy API:
         inputs:

--- a/internal/deployserverclient/deployserver.go
+++ b/internal/deployserverclient/deployserver.go
@@ -2,7 +2,7 @@
 
 package deployserverclient
 
-// Generated from OpenAPI doc version 0.1.0 and generator version 2.799.0
+// Generated from OpenAPI doc version 0.1.0 and generator version 2.797.1
 
 import (
 	"bytes"
@@ -119,7 +119,7 @@ func New(opts ...SDKOption) *DeployServer {
 	sdk := &DeployServer{
 		SDKVersion: "0.0.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/go 0.0.1 2.799.0 0.1.0 github.com/formancehq/fctl/internal/deployserverclient",
+			UserAgent:  "speakeasy-sdk/go 0.0.1 2.797.1 0.1.0 github.com/formancehq/fctl/internal/deployserverclient",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/internal/membershipclient/.speakeasy/gen.lock
+++ b/internal/membershipclient/.speakeasy/gen.lock
@@ -3,14 +3,14 @@ id: 52f53439-fdea-4ef5-bb75-64ae4249026d
 management:
   docChecksum: 2261488416352a021f4f1e4aee627d0a
   docVersion: 0.1.0
-  speakeasyVersion: 1.697.5
-  generationVersion: 2.799.0
+  speakeasyVersion: 1.690.0
+  generationVersion: 2.797.1
   releaseVersion: 0.1.0
   configChecksum: fa7f40ea90d295b423ace405bba25bbb
 persistentEdits:
-  generation_id: bc396be0-6fa1-4573-9450-61f83538e76b
-  pristine_commit_hash: 321680762afe21b33872598522463d9db2f15916
-  pristine_tree_hash: 30ca54484e08698ad3d35e4c15cba8807d63af77
+  generation_id: 690de572-5006-48a4-a40b-4e5f392b1886
+  pristine_commit_hash: 4ae8ab0bdd5e80462dfe758189845507e3a8e4b8
+  pristine_tree_hash: 34a07b3ad7c24c349db57022dfc6aecd76ef9245
 features:
   go:
     additionalDependencies: 0.1.0
@@ -1800,8 +1800,8 @@ trackedFiles:
     pristine_git_object: aa809fccb3445b1e2530a979dad620512f50e70f
   sdk.go:
     id: 8db9b9536b0a
-    last_write_checksum: sha1:65126eb3ca704e94c526a063d7904c561e1b6bd8
-    pristine_git_object: c62fef315313bddd297f5b719820066575bdbd54
+    last_write_checksum: sha1:9d47111b71ddc7497fff4e2b098e9d29bdeb6ae9
+    pristine_git_object: cf4680bfb92f3c78ae4ff14dc038264b90cfd665
   types/bigint.go:
     id: 6f911e1a03c3
     last_write_checksum: sha1:49b004005d0461fb04b846eca062b070b0360b31

--- a/internal/membershipclient/.speakeasy/workflow.lock
+++ b/internal/membershipclient/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.697.5
+speakeasyVersion: 1.690.0
 sources:
     membership:
         sourceNamespace: membership
@@ -15,7 +15,7 @@ targets:
         sourceBlobDigest: sha256:cc9d8d2f899357b7a2062c6d771067ca22ce09546f07087e255c7096e2830e48
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: latest
+    speakeasyVersion: 1.690.0
     sources:
         membership:
             inputs:

--- a/internal/membershipclient/.speakeasy/workflow.yaml
+++ b/internal/membershipclient/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: latest
+speakeasyVersion: 1.690.0 # Should be synced with flake.nix speakeasy version.
 sources:
     membership:
         inputs:

--- a/internal/membershipclient/sdk.go
+++ b/internal/membershipclient/sdk.go
@@ -2,7 +2,7 @@
 
 package membershipclient
 
-// Generated from OpenAPI doc version 0.1.0 and generator version 2.799.0
+// Generated from OpenAPI doc version 0.1.0 and generator version 2.797.1
 
 import (
 	"bytes"
@@ -132,7 +132,7 @@ func New(opts ...SDKOption) *SDK {
 	sdk := &SDK{
 		SDKVersion: "0.1.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/go 0.1.0 2.799.0 0.1.0 github.com/formancehq/fctl/internal/membershipclient",
+			UserAgent:  "speakeasy-sdk/go 0.1.0 2.797.1 0.1.0 github.com/formancehq/fctl/internal/membershipclient",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
Fixes the CI issue where a new speakeasy version is downloaded and would fail the pre-commit check