### PR TITLE
chore(client): Better stack not exist error message

### DIFF
--- a/pkg/clients.go
+++ b/pkg/clients.go
@@ -190,7 +190,7 @@ func EnsureStackAccess(
 
 	if !profile.RootTokens.ID.Claims.HasStackAccess(organizationID, stackID) {
 		return nil, nil, fmt.Errorf("no access to stack %s on organization %s found in your authentication profile, "+
-			"please log in again and/or check you still have access to the organization or that the stack exists", stackID, organizationID)
+			"please log in again and/or check you still have access to the organization or that the stack exists or is not deleted", stackID, organizationID)
 	}
 
 	stackAccess := profile.RootTokens.ID.Claims.


### PR DESCRIPTION
With the change on membership, when an unknown stack is provided, we are not able to know whether it is because they have no access on it or whether is does not exist.

I had this error when trying to access a deleted stack and was confused on this message. (I forgot I deleted the stack)


So this tiny change hints that it may also be because the stack is deleted or non existent.