### PR TITLE
feat: cache stack API tokens to disk and lazy-load OIDC discovery

### DIFF
--- a/cmd/stack/proxy.go
+++ b/cmd/stack/proxy.go
@@ -195,6 +195,10 @@ func (c *ProxyController) Run(cmd *cobra.Command, _ []string) (fctl.Renderable, 
 			func(newToken fctl.AccessToken) error {
 				return fctl.WriteStackToken(cmd, profileName, stackID, newToken)
 			},
+			cmd,
+			profileName,
+			organizationID,
+			stackID,
 		),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/formancehq/formance-sdk-go/v3 v3.7.2
 	github.com/formancehq/go-libs v1.7.2
 	github.com/formancehq/go-libs/v3 v3.4.0
+	github.com/go-jose/go-jose/v4 v4.0.5
 	github.com/iancoleman/strcase v0.3.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/pkg/errors v0.9.1
@@ -43,7 +44,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/go-chi/chi/v5 v5.2.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/pkg/clients.go
+++ b/pkg/clients.go
@@ -451,6 +451,10 @@ func NewStackClient(
 				func(newToken AccessToken) error {
 					return WriteStackToken(cmd, profileName, stackID, newToken)
 				},
+				cmd,
+				profileName,
+				organizationID,
+				stackID,
 			),
 		)),
 	), nil
@@ -540,6 +544,12 @@ type stackTokenSource struct {
 	stackAccess  *StackAccess
 	relyingParty client.RelyingParty
 	onRefresh    func(newToken AccessToken) error
+
+	// Cache fields
+	cmd            *cobra.Command
+	profileName    string
+	organizationID string
+	stackID        string
 }
 
 func (t *stackTokenSource) Token() (*oauth2.Token, error) {
@@ -547,6 +557,19 @@ func (t *stackTokenSource) Token() (*oauth2.Token, error) {
 	defer t.mu.Unlock()
 
 	if t.accessToken == nil || t.accessToken.Expiry.Before(time.Now()) {
+		// Try to load from disk cache
+		if t.cmd != nil {
+			cached, err := ReadCachedStackAPIToken(t.cmd, t.profileName, t.organizationID, t.stackID)
+			if err == nil && cached != nil && cached.Expiry.After(time.Now().Add(5*time.Second)) {
+				t.accessToken = &oauth2.Token{
+					AccessToken: cached.AccessToken,
+					TokenType:   cached.TokenType,
+					Expiry:      cached.Expiry,
+				}
+				return t.accessToken, nil
+			}
+		}
+
 		if t.stackToken.Expired() {
 			newStackToken, err := Refresh(context.Background(), t.relyingParty, t.stackToken)
 			if err != nil {
@@ -564,6 +587,15 @@ func (t *stackTokenSource) Token() (*oauth2.Token, error) {
 		}
 
 		t.accessToken = token
+
+		// Write to disk cache (best-effort)
+		if t.cmd != nil {
+			_ = WriteCachedStackAPIToken(t.cmd, t.profileName, t.organizationID, t.stackID, CachedStackAPIToken{
+				AccessToken: token.AccessToken,
+				TokenType:   token.TokenType,
+				Expiry:      token.Expiry,
+			})
+		}
 	}
 
 	return t.accessToken, nil
@@ -576,12 +608,20 @@ func NewStackTokenSource(
 	stackAccess *StackAccess,
 	relyingParty client.RelyingParty,
 	onRefresh func(newToken AccessToken) error,
+	cmd *cobra.Command,
+	profileName string,
+	organizationID string,
+	stackID string,
 ) oauth2.TokenSource {
 	return &stackTokenSource{
-		stackToken:   stackToken,
-		stackAccess:  stackAccess,
-		relyingParty: relyingParty,
-		onRefresh:    onRefresh,
+		stackToken:     stackToken,
+		stackAccess:    stackAccess,
+		relyingParty:   relyingParty,
+		onRefresh:      onRefresh,
+		cmd:            cmd,
+		profileName:    profileName,
+		organizationID: organizationID,
+		stackID:        stackID,
 	}
 }
 

--- a/pkg/relyingparty.go
+++ b/pkg/relyingparty.go
@@ -2,11 +2,16 @@ package fctl
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"sync"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/pterm/pterm"
+	"golang.org/x/oauth2"
 
 	"github.com/formancehq/go-libs/v3/oidc/client"
+	httphelper "github.com/formancehq/go-libs/v3/oidc/http"
 )
 
 func GetAuthRelyingParty(ctx context.Context, httpClient *http.Client, membershipURI string) (client.RelyingParty, error) {
@@ -20,4 +25,93 @@ func GetAuthRelyingParty(ctx context.Context, httpClient *http.Client, membershi
 		[]string{},
 		client.WithHTTPClient(httpClient),
 	)
+}
+
+// lazyRelyingParty defers the OIDC discovery call until a method (other than
+// HttpClient) is actually invoked. This avoids hitting the .well-known/openid-configuration
+// endpoint when a cached stack API token makes it unnecessary.
+//
+// Uses sync.Mutex instead of sync.Once so that transient discovery failures
+// (e.g. network timeouts) are retried on the next call rather than cached
+// permanently.
+type lazyRelyingParty struct {
+	ctx           context.Context
+	httpClient    *http.Client
+	membershipURI string
+
+	mu       sync.Mutex
+	delegate client.RelyingParty
+}
+
+func (l *lazyRelyingParty) init() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.delegate != nil {
+		return nil
+	}
+	var err error
+	l.delegate, err = GetAuthRelyingParty(l.ctx, l.httpClient, l.membershipURI)
+	return err
+}
+
+func (l *lazyRelyingParty) mustDelegate() client.RelyingParty {
+	if err := l.init(); err != nil {
+		panic(fmt.Sprintf("OIDC discovery failed: %v", err))
+	}
+	return l.delegate
+}
+
+// HttpClient returns the http client without triggering OIDC discovery.
+func (l *lazyRelyingParty) HttpClient() *http.Client {
+	return l.httpClient
+}
+
+func (l *lazyRelyingParty) OAuthConfig() *oauth2.Config {
+	return l.mustDelegate().OAuthConfig()
+}
+func (l *lazyRelyingParty) Issuer() string {
+	return l.mustDelegate().Issuer()
+}
+func (l *lazyRelyingParty) IsPKCE() bool {
+	return l.mustDelegate().IsPKCE()
+}
+func (l *lazyRelyingParty) CookieHandler() *httphelper.CookieHandler {
+	return l.mustDelegate().CookieHandler()
+}
+func (l *lazyRelyingParty) IsOAuth2Only() bool {
+	return l.mustDelegate().IsOAuth2Only()
+}
+func (l *lazyRelyingParty) Signer() jose.Signer {
+	return l.mustDelegate().Signer()
+}
+func (l *lazyRelyingParty) GetEndSessionEndpoint() string {
+	return l.mustDelegate().GetEndSessionEndpoint()
+}
+func (l *lazyRelyingParty) GetRevokeEndpoint() string {
+	return l.mustDelegate().GetRevokeEndpoint()
+}
+func (l *lazyRelyingParty) UserinfoEndpoint() string {
+	return l.mustDelegate().UserinfoEndpoint()
+}
+func (l *lazyRelyingParty) GetDeviceAuthorizationEndpoint() string {
+	return l.mustDelegate().GetDeviceAuthorizationEndpoint()
+}
+func (l *lazyRelyingParty) GetIntrospectionEndpoint() string {
+	return l.mustDelegate().GetIntrospectionEndpoint()
+}
+func (l *lazyRelyingParty) IDTokenVerifier() *client.Verifier {
+	return l.mustDelegate().IDTokenVerifier()
+}
+func (l *lazyRelyingParty) ErrorHandler() func(http.ResponseWriter, *http.Request, string, string, string) {
+	return l.mustDelegate().ErrorHandler()
+}
+
+var _ client.RelyingParty = (*lazyRelyingParty)(nil)
+
+func NewLazyRelyingParty(ctx context.Context, httpClient *http.Client, membershipURI string) client.RelyingParty {
+	return &lazyRelyingParty{
+		ctx:           ctx,
+		httpClient:    httpClient,
+		membershipURI: membershipURI,
+	}
 }


### PR DESCRIPTION
Cache the stack API token (obtained from FetchStackToken) to disk so that repeated CLI invocations skip the stack OIDC discovery and JWT bearer exchange. Also wrap the membership relying party in a lazy proxy that defers the membership OIDC discovery call until actually needed.

With a warm cache, stack commands make zero auth network calls.