### PR TITLE
feat: close all http connections on error

### DIFF
--- a/pkg/command.go
+++ b/pkg/command.go
@@ -17,7 +17,7 @@ var (
 )
 
 func GetSelectedOrganizationID(cmd *cobra.Command) string {
-	return GetString(cmd, organizationFlag)
+	return GetString(cmd, OrganizationFlag)
 }
 
 func ResolveOrganizationID(cmd *cobra.Command, profile Profile) (string, error) {
@@ -40,7 +40,7 @@ func ResolveOrganizationID(cmd *cobra.Command, profile Profile) (string, error) 
 }
 
 func GetSelectedStackID(cmd *cobra.Command, profile Profile) (string, error) {
-	if id := GetString(cmd, stackFlag); id != "" {
+	if id := GetString(cmd, StackFlag); id != "" {
 		return id, nil
 	}
 
@@ -305,7 +305,7 @@ func WithConfirmFlag() CommandOptionFn {
 func NewStackCommand(use string, opts ...CommandOption) *cobra.Command {
 	cmd := NewMembershipCommand(use,
 		append(opts,
-			WithPersistentStringFlag(stackFlag, "", "Specific stack (not required if only one stack is present)"),
+			WithPersistentStringFlag(StackFlag, "", "Specific stack (not required if only one stack is present)"),
 		)...,
 	)
 	if err := cmd.RegisterFlagCompletionFunc("stack", StackCompletion); err != nil {
@@ -317,7 +317,7 @@ func NewStackCommand(use string, opts ...CommandOption) *cobra.Command {
 func NewMembershipCommand(use string, opts ...CommandOption) *cobra.Command {
 	cmd := NewCommand(use,
 		append(opts,
-			WithPersistentStringFlag(organizationFlag, "", "Selected organization (not required if only one organization is present)"),
+			WithPersistentStringFlag(OrganizationFlag, "", "Selected organization (not required if only one organization is present)"),
 		)...,
 	)
 	if err := cmd.RegisterFlagCompletionFunc("organization", OrganizationCompletion); err != nil {

--- a/pkg/flags.go
+++ b/pkg/flags.go
@@ -11,16 +11,17 @@ import (
 )
 
 const (
-	MembershipURIFlag = "membership-uri"
-	ConfigDir         = "config-dir"
-	ProfileFlag       = "profile"
-	OutputFlag        = "output"
-	DebugFlag         = "debug"
-	InsecureTlsFlag   = "insecure-tls"
-	TelemetryFlag     = "telemetry"
-	stackFlag         = "stack"
-	organizationFlag  = "organization"
-	FrameworkURIFlag  = "framework-uri"
+	MembershipURIFlag    = "membership-uri"
+	ConfigDir            = "config-dir"
+	ProfileFlag          = "profile"
+	OutputFlag           = "output"
+	DebugFlag            = "debug"
+	InsecureTlsFlag      = "insecure-tls"
+	HTTPCloseOnErrorFlag = "http-close-on-error"
+	TelemetryFlag        = "telemetry"
+	StackFlag            = "stack"
+	OrganizationFlag     = "organization"
+	FrameworkURIFlag     = "framework-uri"
 )
 
 func GetBool(cmd *cobra.Command, flagName string) bool {

--- a/pkg/http.go
+++ b/pkg/http.go
@@ -19,12 +19,6 @@ func GetHttpClient(cmd *cobra.Command) *http.Client {
 	}
 }
 
-type RoundTripperFn func(req *http.Request) (*http.Response, error)
-
-func (fn RoundTripperFn) RoundTrip(req *http.Request) (*http.Response, error) {
-	return fn(req)
-}
-
 func printBody(data []byte) {
 	if len(data) == 0 {
 		return
@@ -87,23 +81,55 @@ func debugRoundTripper(rt http.RoundTripper) RoundTripperFn {
 }
 
 func NewHTTPTransport(cmd *cobra.Command) http.RoundTripper {
-
-	var transport http.RoundTripper = &http.Transport{
+	var transport = &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: GetBool(cmd, InsecureTlsFlag),
 		},
 	}
+	var roundTripper http.RoundTripper = transport
+
+	if GetBool(cmd, HTTPCloseOnErrorFlag) {
+		roundTripper = &closeOnErrorRoundTripper{
+			transport: transport,
+		}
+	}
+
 	if GetBool(cmd, DebugFlag) {
-		transport = debugRoundTripper(transport)
+		roundTripper = debugRoundTripper(roundTripper)
 	}
 
 	return newInjectHTTPHeadersRoundTripper(
 		http.Header{
 			"User-Agent": []string{fmt.Sprintf("fctl/%s", getVersion(cmd))},
 		},
-		transport,
+		roundTripper,
 	)
 }
+
+var _ http.RoundTripper = (*RoundTripperFn)(nil)
+
+type RoundTripperFn func(req *http.Request) (*http.Response, error)
+
+func (fn RoundTripperFn) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+var _ http.RoundTripper = (*closeOnErrorRoundTripper)(nil)
+
+type closeOnErrorRoundTripper struct {
+	transport *http.Transport
+}
+
+func (rt *closeOnErrorRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rsp, err := rt.transport.RoundTrip(req)
+	if err != nil || rsp.StatusCode >= 400 {
+		_ = rsp.Body.Close()
+		rt.transport.CloseIdleConnections()
+	}
+	return rsp, err
+}
+
+var _ http.RoundTripper = (*injectHTTPHeadersRoundTripper)(nil)
 
 type injectHTTPHeadersRoundTripper struct {
 	headers http.Header

--- a/pkg/http.go
+++ b/pkg/http.go
@@ -123,7 +123,6 @@ type closeOnErrorRoundTripper struct {
 func (rt *closeOnErrorRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	rsp, err := rt.transport.RoundTrip(req)
 	if err != nil || rsp.StatusCode >= 400 {
-		_ = rsp.Body.Close()
 		rt.transport.CloseIdleConnections()
 	}
 	return rsp, err


### PR DESCRIPTION
This force all connections to be closed on errors so that new DNS resolution is enforced for subsequent queries.

Not that useful in fctl but it is in other projects using fctl as a library.