### PR TITLE
fix(ui): bypass organization selection for ui command

### DIFF
--- a/cmd/ui/ui.go
+++ b/cmd/ui/ui.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	membershipclient "github.com/formancehq/fctl/internal/membershipclient/v3"
 	fctl "github.com/formancehq/fctl/v3/pkg"
 )
 
@@ -64,21 +65,20 @@ func (c *UiController) GetStore() *UiStruct {
 
 func (c *UiController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
 
-	_, profile, profileName, relyingParty, err := fctl.LoadAndAuthenticateCurrentProfile(cmd)
+	_, profile, _, relyingParty, err := fctl.LoadAndAuthenticateCurrentProfile(cmd)
 	if err != nil {
 		return nil, err
 	}
 
-	_, apiClient, err := fctl.NewMembershipClientForOrganizationFromFlags(cmd, relyingParty, fctl.NewPTermDialog(), profileName, *profile)
+	cli := membershipclient.New(
+		membershipclient.WithServerURL(profile.GetMembershipURI()),
+		membershipclient.WithClient(relyingParty.HttpClient()),
+	)
+
+	serverInfo, err := fctl.MembershipServerInfo(cmd.Context(), cli)
 	if err != nil {
 		return nil, err
 	}
-
-	serverInfo, err := fctl.MembershipServerInfo(cmd.Context(), apiClient)
-	if err != nil {
-		return nil, err
-	}
-
 	if v := serverInfo.GetConsoleURL(); v != nil {
 		c.store.UIUrl = *v
 	}
@@ -97,7 +97,7 @@ func (c *UiController) Render(cmd *cobra.Command, args []string) error {
 }
 
 func NewCommand() *cobra.Command {
-	return fctl.NewStackCommand("ui",
+	return fctl.NewCommand("ui",
 		fctl.WithShortDescription("Open UI"),
 		fctl.WithArgs(cobra.ExactArgs(0)),
 		fctl.WithValidArgsFunction(cobra.NoFileCompletions),


### PR DESCRIPTION
## Summary
- Refactors `cmd/ui/ui.go` to not require organization selection for opening the console UI
- Uses `fctl.NewCommand` instead of `fctl.NewStackCommand` for the ui command
- Creates membership client directly with `membershipclient.New(...)` to fetch server info, bypassing `NewMembershipClientForOrganizationFromFlags`
- Only cmd/ changes from #115 — SDK regeneration dropped since current main SDK is already correct

## Changes
- `cmd/ui/ui.go`: Changed from `fctl.NewStackCommand` to `fctl.NewCommand`, removing the requirement for organization/stack context
- `cmd/ui/ui.go`: Create membership client directly to get server info (console URL) without organization selection
- Skipped `cmd/stack/create.go` change from #115: the `CreateStackResponse` type on current main still uses `ReadStackResponse` as its field — the PR #115 change was tied to a regenerated SDK that isn't on main
- Skipped `cmd/root.go` change from #115: the `apierrors.Error` type still exists on current main, removing the case would lose error handling

## Test plan
- [ ] Run `fctl ui` without selecting an organization — should open console URL directly
- [ ] Verify `fctl ui` still works when authenticated

Supersedes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)