### PR TITLE
fix(cloud): correct createPrivateRegion response code in OpenAPI spec

### DIFF
--- a/internal/membershipclient/.speakeasy/gen.lock
+++ b/internal/membershipclient/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 52f53439-fdea-4ef5-bb75-64ae4249026d
 management:
-  docChecksum: 2261488416352a021f4f1e4aee627d0a
+  docChecksum: 6b3804ce8f8681b821066d745cee255d
   docVersion: 0.1.0
   speakeasyVersion: 1.759.2
   generationVersion: 2.869.23
-  releaseVersion: 0.1.0
-  configChecksum: f58250d4379f6a9f3a1ad902ed0c16c4
+  releaseVersion: 0.1.1
+  configChecksum: 0f64eb7eb39232558b58f31d69c4a326
 persistentEdits:
-  generation_id: b7a28c8f-ba00-40ec-9e92-4d14b25f2ef7
-  pristine_commit_hash: 789449568448c402aa363a81315fbbdb75e3535f
-  pristine_tree_hash: e401be3e90a47007053b9fa505f8c853546a8dde
+  generation_id: 911da9e8-eec7-4fe5-8180-a3836f2b1b6a
+  pristine_commit_hash: 2608ecf2627911f114f6a47b1bafbf72a0e3d911
+  pristine_tree_hash: ff7bc3857ca60fddbfc48eba60e19861d7dae681
 features:
   go:
     additionalDependencies: 0.1.0
@@ -1800,8 +1800,8 @@ trackedFiles:
     pristine_git_object: 5b3dc7c122d8ab08905485342d7474f8f163888d
   sdk.go:
     id: 8db9b9536b0a
-    last_write_checksum: sha1:9c0431934819fe2afed8f7c2563b1cbcd024b5d1
-    pristine_git_object: 211a697ab4ab325dc867a3deaa9649bef3c3b3aa
+    last_write_checksum: sha1:8fa539a35ad217ebd8e856bbd388c1009f27dabc
+    pristine_git_object: 1311a6078584d2f53ce229db0f1bc35991a54eb2
   types/bigint.go:
     id: 6f911e1a03c3
     last_write_checksum: sha1:49b004005d0461fb04b846eca062b070b0360b31
@@ -2382,6 +2382,8 @@ examples:
           application/json: {"data": {"id": "<id>", "baseUrl": "https://wide-eyed-kinase.org", "createdAt": "2024-12-31T09:20:38.935Z", "active": true, "name": "<value>", "capabilities": {}, "agentID": "<id>", "outdated": true, "organizationID": "<id>", "creatorID": "<value>"}}
         default:
           application/json: {"errorCode": "<value>"}
+        "201":
+          application/json: {"data": {"id": "<id>", "baseUrl": "https://wide-eyed-kinase.org", "createdAt": "2024-12-31T09:20:38.935Z", "active": true, "name": "<value>", "capabilities": {}, "agentID": "<id>", "outdated": true, "organizationID": "<id>", "creatorID": "<value>"}}
   getRegion:
     speakeasy-default-get-region:
       parameters:

--- a/internal/membershipclient/.speakeasy/gen.yaml
+++ b/internal/membershipclient/.speakeasy/gen.yaml
@@ -31,7 +31,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 go:
-  version: 0.1.0
+  version: 0.1.1
   additionalDependencies: {}
   baseErrorName: SDKError
   clientServerStatusCodesAsErrors: true

--- a/internal/membershipclient/sdk.go
+++ b/internal/membershipclient/sdk.go
@@ -130,9 +130,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *SDK {
 	sdk := &SDK{
-		SDKVersion: "0.1.0",
+		SDKVersion: "0.1.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/go 0.1.0 2.869.23 0.1.0 github.com/formancehq/fctl/internal/membershipclient/v3",
+			UserAgent:  "speakeasy-sdk/go 0.1.1 2.869.23 0.1.0 github.com/formancehq/fctl/internal/membershipclient/v3",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),
@@ -12734,7 +12734,7 @@ func (s *SDK) CreatePrivateRegion(ctx context.Context, request operations.Create
 	}
 
 	switch {
-	case httpRes.StatusCode == 200:
+	case httpRes.StatusCode == 201:
 		switch {
 		case utils.MatchContentType(httpRes.Header.Get("Content-Type"), `application/json`):
 			rawBody, err := utils.ConsumeRawBody(httpRes)

--- a/openapi/membership.yaml
+++ b/openapi/membership.yaml
@@ -1675,7 +1675,7 @@ paths:
             schema:
               $ref: "#/components/schemas/CreatePrivateRegionRequest"
       responses:
-        200:
+        201:
           description: Created region
           content:
             application/json:


### PR DESCRIPTION
The membership API returns 201 Created for region creation, but the OpenAPI spec declared 200. The generated SDK ignored the 201 response, leaving CreatedPrivateRegionResponse nil and causing "unexpected response: no data".

Constraint: SDK is Speakeasy-generated — must fix at the spec level
Rejected: Hand-edit sdk.go | would be overwritten on next generation
Confidence: high
Scope-risk: narrow