### PR TITLE
fix(ledger): remove implicit 7-day sliding window on volumes list

### DIFF
--- a/cmd/ledger/volumes/list.go
+++ b/cmd/ledger/volumes/list.go
@@ -2,7 +2,6 @@ package volumes
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -86,16 +85,6 @@ func (c *ListController) Run(cmd *cobra.Command, args []string) (fctl.Renderable
 	oot, err := fctl.GetDateTime(cmd, c.ootFlag)
 	if err != nil {
 		return nil, err
-	}
-
-	if pit == nil {
-		tmp := time.Now()
-		pit = &tmp
-	}
-
-	if oot == nil {
-		tmp := pit.Add(-24 * 7 * time.Hour)
-		oot = &tmp
 	}
 
 	request := operations.V2GetVolumesWithBalancesRequest{


### PR DESCRIPTION
## Summary

`fctl ledger volumes list` silently injected default time boundaries, causing **incorrect Point-in-Time (PIT) volume queries**.

When a user ran:
```bash
fctl ledger volumes list --end-time "2025-06-12T12:00:00Z"
```

fctl sent **both** `endTime=2025-06-12` **and** `startTime=2025-06-05` (endTime minus 7 days) to the ledger API, even though the user never provided `--start-time`.

This caused the ledger to generate:
```sql
WHERE effective_date <= '2025-06-12' AND effective_date >= '2025-06-05'
```

Instead of the expected:
```sql
WHERE effective_date <= '2025-06-12'
```

Any move older than 7 days before the requested PIT date was invisible, making volumes appear and disappear depending on the chosen date — which is incorrect for immutable ledger data.

## Root cause

In `cmd/ledger/volumes/list.go`, two default blocks injected time boundaries when the user did not provide them:

```go
// Defaulted endTime to now when not provided
if pit == nil {
    tmp := time.Now()
    pit = &tmp
}

// Defaulted startTime to endTime - 7 days when not provided
if oot == nil {
    tmp := pit.Add(-24 * 7 * time.Hour)
    oot = &tmp
}
```

The ledger server handles missing parameters correctly: when no `startTime` is sent, it queries all moves from the beginning of time up to `endTime`. The default injection was entirely client-side in fctl and never requested by the user.

## Behavior change

| Scenario | Before (broken) | After (fixed) |
|----------|-----------------|---------------|
| `--end-time` only | Sends `endTime` + `startTime` (endTime - 7d) | Sends `endTime` only → true PIT query |
| `--start-time` only | Sends `startTime` + `endTime` (now) | Sends `startTime` only |
| Both flags | Sends both (correct) | Sends both (unchanged) |
| Neither flag | Sends `endTime=now` + `startTime=now-7d` | Sends neither → all data |

> **⚠️ Breaking behavior change:** Users who relied on the implicit 7-day window (without knowing it existed) will now get results covering the full ledger history. This is the **correct** behavior — the previous default was silently filtering out data.

## Verification

Tested against a production stack. With the fix, `go run ./ ledger volumes list --end-time <date>` returns the correct volumes covering all historical moves, while the installed `fctl` returns empty results due to the 7-day window excluding the relevant transactions.

## Test plan

- [ ] Run `fctl ledger volumes list --end-time <date>` → should return all volumes up to that date (no lower bound)
- [ ] Run `fctl ledger volumes list --start-time <date> --end-time <date>` → should return volumes in the explicit range
- [ ] Run `fctl ledger volumes list` without time flags → should return all volumes
- [ ] Run `fctl ledger volumes list --start-time <date>` → should return volumes from that date onward