### PR TITLE
chore(ci): migrate from Shipfox to Namespace.so runners

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -9,27 +9,14 @@ runs:
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v31
-    ## Disabling cache for now, as it's slowing down the build. Downloading nix
-    ## dependencies from cache.nixos.org is faster than restoring from the cache.
-    #- name: Cache dependencies
-    #  uses: nix-community/cache-nix-action@v6
-    #  with:
-    #    primary-key: nix-${{ runner.os }}-${{ hashFiles('**/flake.nix', '**/flake.lock') }}
-    #    restore-prefixes-first-match: nix-${{ runner.os }}-
-    - name: Load dependencies
-      shell: bash
-      run: nix develop --install
     - name: go env
       id: go-env
       shell: bash
       run: |
         nix develop --command bash -c "go env | sed -E \"s/^([^=]+)='(.*)'\$/\1=\2/\"" >> "$GITHUB_OUTPUT"
-    - uses: actions/cache@v5
+    - uses: namespacelabs/nscloud-cache-action@v1
       with:
         path: |
           ${{ steps.go-env.outputs.GOCACHE }}
           ${{ steps.go-env.outputs.GOMODCACHE }}
           ~/.cache/golangci-lint
-        key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.job }}-go-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,12 +26,12 @@ jobs:
 
   Tests:
     name: Tests
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: actions/checkout@v6
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
-          filter: tree:0
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
         with:
@@ -39,15 +39,15 @@ jobs:
       - run: nix develop --impure --command just tests
 
   Dirty:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     env:
       GOPATH: /tmp/go
       GOLANGCI_LINT_CACHE: /tmp/golangci-lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
-          filter: tree:0 # treeless clone, faster to clone as history and blobs are only fetched when needed.
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
         with:
@@ -69,23 +69,21 @@ jobs:
           fi
 
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     needs:
       - Dirty
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - uses: earthly/actions-setup@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: "latest"
-      - uses: actions/checkout@v6
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
-          filter: tree:0 # treeless clone, faster to clone as history and blobs are only fetched when needed.
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
         with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,20 +8,18 @@ permissions:
 
 jobs:
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: actions/checkout@v6
+      - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 0
-          filter: tree:0
+          dissociate: true
       - name: Setup Env
         uses: ./.github/actions/default
         with:
           token: ${{ secrets.NUMARY_GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Summary

Migrate CI runners from Shipfox to Namespace.so as part of the org-wide CI infrastructure migration.

### Per-workflow changes
- `runs-on: shipfox-Xvcpu-ubuntu-2404` → `runs-on: namespace-profile-linux-amd64-Xvcpu`
- `actions/checkout@v6` → `namespacelabs/nscloud-checkout-action@v7` (git mirror caching)
- `docker/setup-qemu-action` removed (Namespace builds AMD64+ARM64 natively without emulation)
- `docker/setup-buildx-action` → `namespacelabs/nscloud-setup-buildx-action@v0` (Remote Builders)

### Composite changes
- `nix-community/cache-nix-action` removed (incompatible with Namespace runner setup)
- `actions/cache` → `namespacelabs/nscloud-cache-action@v1` (paths preserved)

### Validation
- Reference migration: formancehq/ledger#1336 plus 4× banking-bridge + 16 other repos already merged or green.

## Test plan
- [ ] CI passes on this PR
- [ ] No regression in build duration vs prior shipfox runs
