### PR TITLE
fix: update CODEOWNERS team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @formancehq/backend
+* @formancehq/engineer


### PR DESCRIPTION
## Summary

- replace the removed `@formancehq/backend` CODEOWNER with `@formancehq/engineer`
- keep the existing repository-wide ownership scope unchanged

## Validation

- `git diff --check`
- confirmed the `engineer` organization team exists
- GitHub CODEOWNERS validation reports no errors on this branch