### PR TITLE
chore: remove search module reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Command-line interface for managing and interacting with Formance services.
 - Authentication
 - Stack management
 - Cloud resources
-- Search functionality
 - Webhooks configuration
 
 ## Installation
@@ -83,4 +82,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Links
 
 - [Formance Documentation](https://docs.formance.com)
-- [Formance GitHub](https://github.com/formancehq) 
+- [Formance GitHub](https://github.com/formancehq)


### PR DESCRIPTION
## What changed

- remove Search from the README's advertised fctl capabilities
- keep the remaining generic trigger name filter unchanged because it is unrelated to the Formance Search module

## Why

The Formance Search module is no longer deployable and should not be presented as a supported fctl capability. Its CLI implementation and root command wiring were already removed when the Formance SDK was upgraded to v4 in PR #163; this change removes the final stale product reference from the tracked repository.

## Impact

Users will no longer see Search advertised as an available fctl feature. There is no runtime behavior change because the command is already absent.

## Validation

- `go test ./...`
- `git diff --check`
- repository-wide search for Search module packages, clients, and command wiring