### PR TITLE
feat(webhooks): expose latest endpoint commands

### DIFF
--- a/cmd/webhooks/deliveries.go
+++ b/cmd/webhooks/deliveries.go
@@ -260,7 +260,7 @@ func authenticatedDeliveriesAPI(cmd *cobra.Command) (*deliveriesAPI, error) {
 
 func NewDeliveriesCommand() *cobra.Command {
 	return fctl.NewCommand("deliveries",
-		fctl.WithAliases("delivery", "del"),
+		fctl.WithAliases("delivery", "dlvs"),
 		fctl.WithShortDescription("Inspect and replay webhook deliveries"),
 		fctl.WithChildCommands(
 			NewListDeliveriesCommand(),

--- a/cmd/webhooks/deliveries.go
+++ b/cmd/webhooks/deliveries.go
@@ -1,0 +1,338 @@
+package webhooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+const (
+	deliveryStatusFlag  = "status"
+	configIDFlag        = "config-id"
+	createdAtFromFlag   = "created-at-from"
+	createdAtToFlag     = "created-at-to"
+	idempotencyKeyFlag  = "idempotency-key"
+	endpointFlag        = "endpoint"
+	maxDeliveryPageSize = 1000
+)
+
+type DeliveryStatus string
+
+const (
+	DeliveryStatusPending    DeliveryStatus = "pending"
+	DeliveryStatusDelivering DeliveryStatus = "delivering"
+	DeliveryStatusSucceeded  DeliveryStatus = "succeeded"
+	DeliveryStatusFailed     DeliveryStatus = "failed"
+	DeliveryStatusCancelled  DeliveryStatus = "cancelled"
+)
+
+type Delivery struct {
+	ID               string         `json:"id"`
+	EventID          string         `json:"eventID"`
+	IdempotencyKey   string         `json:"idempotencyKey,omitempty"`
+	ConfigID         string         `json:"configID"`
+	EventType        string         `json:"eventType"`
+	Payload          string         `json:"payload,omitempty"`
+	Status           DeliveryStatus `json:"status"`
+	AttemptCount     int            `json:"attemptCount"`
+	ReplayGeneration int            `json:"replayGeneration"`
+	CycleStartedAt   *time.Time     `json:"cycleStartedAt,omitempty"`
+	NextAttemptAt    *time.Time     `json:"nextAttemptAt,omitempty"`
+	ClaimedAt        *time.Time     `json:"claimedAt,omitempty"`
+	LastAttemptAt    *time.Time     `json:"lastAttemptAt,omitempty"`
+	LastStatusCode   *int           `json:"lastStatusCode,omitempty"`
+	LastError        string         `json:"lastError,omitempty"`
+	CreatedAt        time.Time      `json:"createdAt"`
+	UpdatedAt        time.Time      `json:"updatedAt"`
+}
+
+type DeliveryAttempt struct {
+	ID               string    `json:"id"`
+	DeliveryID       string    `json:"deliveryID"`
+	AttemptNumber    int       `json:"attemptNumber"`
+	ReplayGeneration int       `json:"replayGeneration"`
+	Endpoint         string    `json:"endpoint"`
+	Outcome          string    `json:"outcome"`
+	StatusCode       int       `json:"statusCode"`
+	Error            string    `json:"error,omitempty"`
+	DurationMillis   int64     `json:"durationMillis,omitempty"`
+	ResponseExcerpt  string    `json:"responseExcerpt,omitempty"`
+	CreatedAt        time.Time `json:"createdAt"`
+}
+
+type deliveryCursor[T any] struct {
+	PageSize int     `json:"pageSize"`
+	HasMore  bool    `json:"hasMore"`
+	Next     *string `json:"next,omitempty"`
+	Data     []T     `json:"data"`
+}
+
+type deliveriesResponse struct {
+	Cursor deliveryCursor[Delivery] `json:"cursor"`
+}
+
+type deliveryResponse struct {
+	Data Delivery `json:"data"`
+}
+
+type deliveryAttemptsResponse struct {
+	Cursor deliveryCursor[DeliveryAttempt] `json:"cursor"`
+}
+
+type replayDeliveriesRequest struct {
+	CreatedAtFrom time.Time        `json:"createdAtFrom"`
+	CreatedAtTo   *time.Time       `json:"createdAtTo,omitempty"`
+	Statuses      []DeliveryStatus `json:"statuses,omitempty"`
+	ConfigIDs     []string         `json:"configIds,omitempty"`
+	Cursor        *string          `json:"cursor,omitempty"`
+	PageSize      int              `json:"pageSize,omitempty"`
+}
+
+type ReplayDeliveriesResult struct {
+	Replayed    int       `json:"replayed"`
+	Expedited   int       `json:"expedited"`
+	Skipped     int       `json:"skipped"`
+	HasMore     bool      `json:"hasMore"`
+	NextCursor  *string   `json:"nextCursor,omitempty"`
+	CreatedAtTo time.Time `json:"createdAtTo"`
+}
+
+type replayDeliveriesResponse struct {
+	Data ReplayDeliveriesResult `json:"data"`
+}
+
+type listDeliveriesParams struct {
+	ConfigID      string
+	Status        DeliveryStatus
+	CreatedAtFrom *time.Time
+	CreatedAtTo   *time.Time
+	Cursor        string
+	PageSize      int
+}
+
+type deliveriesAPI struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func newDeliveriesAPI(baseURL string, httpClient *http.Client) *deliveriesAPI {
+	return &deliveriesAPI{baseURL: baseURL, httpClient: httpClient}
+}
+
+func (c *deliveriesAPI) list(ctx context.Context, params listDeliveriesParams) (*deliveriesResponse, error) {
+	query := url.Values{}
+	query.Set("pageSize", strconv.Itoa(params.PageSize))
+	if params.ConfigID != "" {
+		query.Set("configId", params.ConfigID)
+	}
+	if params.Status != "" {
+		query.Set("status", string(params.Status))
+	}
+	if params.CreatedAtFrom != nil {
+		query.Set("createdAtFrom", params.CreatedAtFrom.Format(time.RFC3339))
+	}
+	if params.CreatedAtTo != nil {
+		query.Set("createdAtTo", params.CreatedAtTo.Format(time.RFC3339))
+	}
+	if params.Cursor != "" {
+		query.Set("cursor", params.Cursor)
+	}
+
+	response := &deliveriesResponse{}
+	if err := c.do(ctx, http.MethodGet, "/api/webhooks/deliveries", query, "", nil, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (c *deliveriesAPI) get(ctx context.Context, id string) (*deliveryResponse, error) {
+	response := &deliveryResponse{}
+	if err := c.do(ctx, http.MethodGet, "/api/webhooks/deliveries/"+url.PathEscape(id), nil, "", nil, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (c *deliveriesAPI) attempts(ctx context.Context, id, cursor string, pageSize int) (*deliveryAttemptsResponse, error) {
+	query := url.Values{"pageSize": []string{strconv.Itoa(pageSize)}}
+	if cursor != "" {
+		query.Set("cursor", cursor)
+	}
+	response := &deliveryAttemptsResponse{}
+	if err := c.do(ctx, http.MethodGet, "/api/webhooks/deliveries/"+url.PathEscape(id)+"/attempts", query, "", nil, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (c *deliveriesAPI) replay(ctx context.Context, id, idempotencyKey string) (*deliveryResponse, error) {
+	response := &deliveryResponse{}
+	if err := c.do(ctx, http.MethodPost, "/api/webhooks/deliveries/"+url.PathEscape(id)+"/replay", nil, idempotencyKey, nil, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (c *deliveriesAPI) replayMany(ctx context.Context, idempotencyKey string, body replayDeliveriesRequest) (*replayDeliveriesResponse, error) {
+	response := &replayDeliveriesResponse{}
+	if err := c.do(ctx, http.MethodPost, "/api/webhooks/deliveries/replay", nil, idempotencyKey, body, response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (c *deliveriesAPI) do(ctx context.Context, method, path string, query url.Values, idempotencyKey string, body, result any) error {
+	endpoint, err := url.JoinPath(c.baseURL, path)
+	if err != nil {
+		return fmt.Errorf("building webhooks URL: %w", err)
+	}
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encoding request: %w", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
+
+	response, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling webhooks: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		data, readErr := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+		if readErr != nil {
+			return fmt.Errorf("webhooks returned status %d (reading response: %w)", response.StatusCode, readErr)
+		}
+		message := strings.TrimSpace(string(data))
+		if message == "" {
+			return fmt.Errorf("webhooks returned status %d", response.StatusCode)
+		}
+		return fmt.Errorf("webhooks returned status %d: %s", response.StatusCode, message)
+	}
+
+	if err := json.NewDecoder(response.Body).Decode(result); err != nil {
+		return fmt.Errorf("decoding webhooks response: %w", err)
+	}
+	return nil
+}
+
+func authenticatedDeliveriesAPI(cmd *cobra.Command) (*deliveriesAPI, error) {
+	_, profile, profileName, relyingParty, err := fctl.LoadAndAuthenticateCurrentProfile(cmd)
+	if err != nil {
+		return nil, err
+	}
+	clients, err := fctl.NewStackClientsFromFlags(cmd, relyingParty, fctl.NewPTermDialog(), profileName, *profile)
+	if err != nil {
+		return nil, err
+	}
+	return newDeliveriesAPI(clients.URI, clients.HTTPClient), nil
+}
+
+func NewDeliveriesCommand() *cobra.Command {
+	return fctl.NewCommand("deliveries",
+		fctl.WithAliases("delivery", "del"),
+		fctl.WithShortDescription("Inspect and replay webhook deliveries"),
+		fctl.WithChildCommands(
+			NewListDeliveriesCommand(),
+			NewShowDeliveryCommand(),
+			NewListDeliveryAttemptsCommand(),
+			NewReplayDeliveryCommand(),
+			NewReplayDeliveriesCommand(),
+		),
+	)
+}
+
+func deliveryStatus(value string, replayOnly bool) (DeliveryStatus, error) {
+	status := DeliveryStatus(value)
+	switch status {
+	case "":
+		return "", nil
+	case DeliveryStatusFailed, DeliveryStatusPending:
+		return status, nil
+	case DeliveryStatusDelivering, DeliveryStatusSucceeded, DeliveryStatusCancelled:
+		if !replayOnly {
+			return status, nil
+		}
+	}
+	if replayOnly {
+		return "", fmt.Errorf("invalid delivery status %q: expected failed or pending", value)
+	}
+	return "", fmt.Errorf("invalid delivery status %q", value)
+}
+
+func deliveryPageSize(cmd *cobra.Command) (int, error) {
+	pageSize, err := fctl.GetPageSize(cmd)
+	if err != nil {
+		return 0, err
+	}
+	if pageSize > maxDeliveryPageSize {
+		return 0, fmt.Errorf("page size must not exceed %d", maxDeliveryPageSize)
+	}
+	return int(pageSize), nil
+}
+
+func optionalTime(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return value.Format(time.RFC3339)
+}
+
+func optionalInt(value *int) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.Itoa(*value)
+}
+
+func renderDelivery(cmd *cobra.Command, delivery Delivery) error {
+	return pterm.DefaultTable.WithWriter(cmd.OutOrStdout()).WithData(pterm.TableData{
+		{"ID", delivery.ID},
+		{"Event ID", delivery.EventID},
+		{"Idempotency key", delivery.IdempotencyKey},
+		{"Config ID", delivery.ConfigID},
+		{"Event type", delivery.EventType},
+		{"Status", string(delivery.Status)},
+		{"Attempt count", strconv.Itoa(delivery.AttemptCount)},
+		{"Replay generation", strconv.Itoa(delivery.ReplayGeneration)},
+		{"Cycle started at", optionalTime(delivery.CycleStartedAt)},
+		{"Next attempt at", optionalTime(delivery.NextAttemptAt)},
+		{"Claimed at", optionalTime(delivery.ClaimedAt)},
+		{"Last attempt at", optionalTime(delivery.LastAttemptAt)},
+		{"Last status code", optionalInt(delivery.LastStatusCode)},
+		{"Last error", delivery.LastError},
+		{"Created at", delivery.CreatedAt.Format(time.RFC3339)},
+		{"Updated at", delivery.UpdatedAt.Format(time.RFC3339)},
+		{"Payload", delivery.Payload},
+	}).Render()
+}

--- a/cmd/webhooks/deliveries.go
+++ b/cmd/webhooks/deliveries.go
@@ -301,6 +301,14 @@ func deliveryPageSize(cmd *cobra.Command) (int, error) {
 	return int(pageSize), nil
 }
 
+func requiredIdempotencyKey(cmd *cobra.Command) (string, error) {
+	key := fctl.GetString(cmd, idempotencyKeyFlag)
+	if key == "" {
+		return "", fmt.Errorf("--%s is required", idempotencyKeyFlag)
+	}
+	return key, nil
+}
+
 func optionalTime(value *time.Time) string {
 	if value == nil {
 		return ""

--- a/cmd/webhooks/deliveries_attempts.go
+++ b/cmd/webhooks/deliveries_attempts.go
@@ -1,0 +1,84 @@
+package webhooks
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type ListDeliveryAttemptsStore struct {
+	Attempts []DeliveryAttempt `json:"attempts"`
+	Cursor   fctl.Cursor       `json:"cursor"`
+}
+
+type ListDeliveryAttemptsController struct {
+	store *ListDeliveryAttemptsStore
+}
+
+func NewListDeliveryAttemptsController() *ListDeliveryAttemptsController {
+	return &ListDeliveryAttemptsController{store: &ListDeliveryAttemptsStore{Attempts: []DeliveryAttempt{}}}
+}
+
+func (c *ListDeliveryAttemptsController) GetStore() *ListDeliveryAttemptsStore { return c.store }
+
+func (c *ListDeliveryAttemptsController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	pageSize, err := deliveryPageSize(cmd)
+	if err != nil {
+		return nil, err
+	}
+	cursor, err := fctl.GetCursor(cmd)
+	if err != nil {
+		return nil, err
+	}
+	api, err := authenticatedDeliveriesAPI(cmd)
+	if err != nil {
+		return nil, err
+	}
+	response, err := api.attempts(cmd.Context(), args[0], cursor, pageSize)
+	if err != nil {
+		return nil, fmt.Errorf("listing delivery attempts: %w", err)
+	}
+	c.store.Attempts = response.Cursor.Data
+	c.store.Cursor = fctl.Cursor{
+		HasMore:  response.Cursor.HasMore,
+		PageSize: int64(response.Cursor.PageSize),
+		Next:     response.Cursor.Next,
+	}
+	return c, nil
+}
+
+func (c *ListDeliveryAttemptsController) Render(cmd *cobra.Command, _ []string) error {
+	table := pterm.TableData{{"ID", "Attempt", "Replay gen.", "Outcome", "Status", "Duration (ms)", "Created at", "Error"}}
+	for _, attempt := range c.store.Attempts {
+		table = append(table, []string{
+			attempt.ID,
+			strconv.Itoa(attempt.AttemptNumber),
+			strconv.Itoa(attempt.ReplayGeneration),
+			attempt.Outcome,
+			strconv.Itoa(attempt.StatusCode),
+			strconv.FormatInt(attempt.DurationMillis, 10),
+			attempt.CreatedAt.Format(time.RFC3339),
+			attempt.Error,
+		})
+	}
+	if err := pterm.DefaultTable.WithHasHeader(true).WithWriter(cmd.OutOrStdout()).WithData(table).Render(); err != nil {
+		return fmt.Errorf("rendering delivery attempts: %w", err)
+	}
+	return fctl.RenderCursor(cmd.OutOrStdout(), c.store.Cursor)
+}
+
+func NewListDeliveryAttemptsCommand() *cobra.Command {
+	return fctl.NewCommand("attempts <delivery-id>",
+		fctl.WithShortDescription("List the attempts for a webhook delivery"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithCursorFlag(),
+		fctl.WithPageSizeFlag(),
+		fctl.WithController[*ListDeliveryAttemptsStore](NewListDeliveryAttemptsController()),
+	)
+}

--- a/cmd/webhooks/deliveries_list.go
+++ b/cmd/webhooks/deliveries_list.go
@@ -1,0 +1,110 @@
+package webhooks
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type ListDeliveriesStore struct {
+	Deliveries []Delivery  `json:"deliveries"`
+	Cursor     fctl.Cursor `json:"cursor"`
+}
+
+type ListDeliveriesController struct {
+	store *ListDeliveriesStore
+}
+
+func NewListDeliveriesController() *ListDeliveriesController {
+	return &ListDeliveriesController{store: &ListDeliveriesStore{Deliveries: []Delivery{}}}
+}
+
+func (c *ListDeliveriesController) GetStore() *ListDeliveriesStore { return c.store }
+
+func (c *ListDeliveriesController) Run(cmd *cobra.Command, _ []string) (fctl.Renderable, error) {
+	status, err := deliveryStatus(fctl.GetString(cmd, deliveryStatusFlag), false)
+	if err != nil {
+		return nil, err
+	}
+	createdAtFrom, err := fctl.GetDateTime(cmd, createdAtFromFlag)
+	if err != nil {
+		return nil, fmt.Errorf("parsing --%s: %w", createdAtFromFlag, err)
+	}
+	createdAtTo, err := fctl.GetDateTime(cmd, createdAtToFlag)
+	if err != nil {
+		return nil, fmt.Errorf("parsing --%s: %w", createdAtToFlag, err)
+	}
+	pageSize, err := deliveryPageSize(cmd)
+	if err != nil {
+		return nil, err
+	}
+	cursor, err := fctl.GetCursor(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	api, err := authenticatedDeliveriesAPI(cmd)
+	if err != nil {
+		return nil, err
+	}
+	response, err := api.list(cmd.Context(), listDeliveriesParams{
+		ConfigID:      fctl.GetString(cmd, configIDFlag),
+		Status:        status,
+		CreatedAtFrom: createdAtFrom,
+		CreatedAtTo:   createdAtTo,
+		Cursor:        cursor,
+		PageSize:      pageSize,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing deliveries: %w", err)
+	}
+
+	c.store.Deliveries = response.Cursor.Data
+	c.store.Cursor = fctl.Cursor{
+		HasMore:  response.Cursor.HasMore,
+		PageSize: int64(response.Cursor.PageSize),
+		Next:     response.Cursor.Next,
+	}
+	return c, nil
+}
+
+func (c *ListDeliveriesController) Render(cmd *cobra.Command, _ []string) error {
+	table := pterm.TableData{{"ID", "Config ID", "Event type", "Status", "Attempts", "Replay gen.", "Last status", "Created at"}}
+	for _, delivery := range c.store.Deliveries {
+		table = append(table, []string{
+			delivery.ID,
+			delivery.ConfigID,
+			delivery.EventType,
+			string(delivery.Status),
+			strconv.Itoa(delivery.AttemptCount),
+			strconv.Itoa(delivery.ReplayGeneration),
+			optionalInt(delivery.LastStatusCode),
+			delivery.CreatedAt.Format(time.RFC3339),
+		})
+	}
+	if err := pterm.DefaultTable.WithHasHeader(true).WithWriter(cmd.OutOrStdout()).WithData(table).Render(); err != nil {
+		return fmt.Errorf("rendering deliveries: %w", err)
+	}
+	return fctl.RenderCursor(cmd.OutOrStdout(), c.store.Cursor)
+}
+
+func NewListDeliveriesCommand() *cobra.Command {
+	return fctl.NewCommand("list",
+		fctl.WithAliases("ls", "l"),
+		fctl.WithShortDescription("List webhook deliveries"),
+		fctl.WithArgs(cobra.NoArgs),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithStringFlag(configIDFlag, "", "Filter by webhook config ID"),
+		fctl.WithStringFlag(deliveryStatusFlag, "", "Filter by status (pending, delivering, succeeded, failed, cancelled)"),
+		fctl.WithStringFlag(createdAtFromFlag, "", "Filter deliveries created at or after this RFC3339 timestamp"),
+		fctl.WithStringFlag(createdAtToFlag, "", "Filter deliveries created at or before this RFC3339 timestamp"),
+		fctl.WithCursorFlag(),
+		fctl.WithPageSizeFlag(),
+		fctl.WithController[*ListDeliveriesStore](NewListDeliveriesController()),
+	)
+}

--- a/cmd/webhooks/deliveries_replay.go
+++ b/cmd/webhooks/deliveries_replay.go
@@ -24,6 +24,10 @@ func NewReplayDeliveryController() *ReplayDeliveryController {
 func (c *ReplayDeliveryController) GetStore() *ReplayDeliveryStore { return c.store }
 
 func (c *ReplayDeliveryController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	idempotencyKey, err := requiredIdempotencyKey(cmd)
+	if err != nil {
+		return nil, err
+	}
 	if !fctl.CheckStackApprobation(cmd, "You are about to replay webhook delivery %s", args[0]) {
 		return nil, fctl.ErrMissingApproval
 	}
@@ -31,7 +35,7 @@ func (c *ReplayDeliveryController) Run(cmd *cobra.Command, args []string) (fctl.
 	if err != nil {
 		return nil, err
 	}
-	response, err := api.replay(cmd.Context(), args[0], fctl.GetString(cmd, idempotencyKeyFlag))
+	response, err := api.replay(cmd.Context(), args[0], idempotencyKey)
 	if err != nil {
 		return nil, fmt.Errorf("replaying delivery: %w", err)
 	}
@@ -45,7 +49,7 @@ func (c *ReplayDeliveryController) Render(cmd *cobra.Command, _ []string) error 
 }
 
 func NewReplayDeliveryCommand() *cobra.Command {
-	cmd := fctl.NewCommand("replay <delivery-id>",
+	return fctl.NewCommand("replay <delivery-id>",
 		fctl.WithShortDescription("Replay one failed or pending webhook delivery"),
 		fctl.WithArgs(cobra.ExactArgs(1)),
 		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
@@ -53,8 +57,4 @@ func NewReplayDeliveryCommand() *cobra.Command {
 		fctl.WithConfirmFlag(),
 		fctl.WithController[*ReplayDeliveryStore](NewReplayDeliveryController()),
 	)
-	if err := cmd.MarkFlagRequired(idempotencyKeyFlag); err != nil {
-		panic(err)
-	}
-	return cmd
 }

--- a/cmd/webhooks/deliveries_replay.go
+++ b/cmd/webhooks/deliveries_replay.go
@@ -1,0 +1,60 @@
+package webhooks
+
+import (
+	"fmt"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type ReplayDeliveryStore struct {
+	Delivery Delivery `json:"delivery"`
+}
+
+type ReplayDeliveryController struct {
+	store *ReplayDeliveryStore
+}
+
+func NewReplayDeliveryController() *ReplayDeliveryController {
+	return &ReplayDeliveryController{store: &ReplayDeliveryStore{}}
+}
+
+func (c *ReplayDeliveryController) GetStore() *ReplayDeliveryStore { return c.store }
+
+func (c *ReplayDeliveryController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	if !fctl.CheckStackApprobation(cmd, "You are about to replay webhook delivery %s", args[0]) {
+		return nil, fctl.ErrMissingApproval
+	}
+	api, err := authenticatedDeliveriesAPI(cmd)
+	if err != nil {
+		return nil, err
+	}
+	response, err := api.replay(cmd.Context(), args[0], fctl.GetString(cmd, idempotencyKeyFlag))
+	if err != nil {
+		return nil, fmt.Errorf("replaying delivery: %w", err)
+	}
+	c.store.Delivery = response.Data
+	return c, nil
+}
+
+func (c *ReplayDeliveryController) Render(cmd *cobra.Command, _ []string) error {
+	pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Delivery queued for replay")
+	return renderDelivery(cmd, c.store.Delivery)
+}
+
+func NewReplayDeliveryCommand() *cobra.Command {
+	cmd := fctl.NewCommand("replay <delivery-id>",
+		fctl.WithShortDescription("Replay one failed or pending webhook delivery"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithStringFlag(idempotencyKeyFlag, "", "Idempotency key for this replay request"),
+		fctl.WithConfirmFlag(),
+		fctl.WithController[*ReplayDeliveryStore](NewReplayDeliveryController()),
+	)
+	if err := cmd.MarkFlagRequired(idempotencyKeyFlag); err != nil {
+		panic(err)
+	}
+	return cmd
+}

--- a/cmd/webhooks/deliveries_replay_bulk.go
+++ b/cmd/webhooks/deliveries_replay_bulk.go
@@ -27,9 +27,6 @@ func NewReplayDeliveriesController() *ReplayDeliveriesController {
 func (c *ReplayDeliveriesController) GetStore() *ReplayDeliveriesStore { return c.store }
 
 func (c *ReplayDeliveriesController) Run(cmd *cobra.Command, _ []string) (fctl.Renderable, error) {
-	if !fctl.CheckStackApprobation(cmd, "You are about to replay a page of webhook deliveries") {
-		return nil, fctl.ErrMissingApproval
-	}
 	createdAtFrom, err := fctl.GetDateTime(cmd, createdAtFromFlag)
 	if err != nil {
 		return nil, fmt.Errorf("parsing --%s: %w", createdAtFromFlag, err)
@@ -42,6 +39,10 @@ func (c *ReplayDeliveriesController) Run(cmd *cobra.Command, _ []string) (fctl.R
 		return nil, fmt.Errorf("parsing --%s: %w", createdAtToFlag, err)
 	}
 	pageSize, err := deliveryPageSize(cmd)
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, err := requiredIdempotencyKey(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -71,11 +72,14 @@ func (c *ReplayDeliveriesController) Run(cmd *cobra.Command, _ []string) (fctl.R
 		request.Cursor = &cursor
 	}
 
+	if !fctl.CheckStackApprobation(cmd, "You are about to replay a page of webhook deliveries") {
+		return nil, fctl.ErrMissingApproval
+	}
 	api, err := authenticatedDeliveriesAPI(cmd)
 	if err != nil {
 		return nil, err
 	}
-	response, err := api.replayMany(cmd.Context(), fctl.GetString(cmd, idempotencyKeyFlag), request)
+	response, err := api.replayMany(cmd.Context(), idempotencyKey, request)
 	if err != nil {
 		return nil, fmt.Errorf("replaying deliveries: %w", err)
 	}
@@ -102,7 +106,7 @@ func (c *ReplayDeliveriesController) Render(cmd *cobra.Command, _ []string) erro
 }
 
 func NewReplayDeliveriesCommand() *cobra.Command {
-	cmd := fctl.NewCommand("replay-bulk",
+	return fctl.NewCommand("replay-bulk",
 		fctl.WithShortDescription("Replay a bounded page of failed or pending webhook deliveries"),
 		fctl.WithArgs(cobra.NoArgs),
 		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
@@ -116,10 +120,4 @@ func NewReplayDeliveriesCommand() *cobra.Command {
 		fctl.WithConfirmFlag(),
 		fctl.WithController[*ReplayDeliveriesStore](NewReplayDeliveriesController()),
 	)
-	for _, flag := range []string{createdAtFromFlag, idempotencyKeyFlag} {
-		if err := cmd.MarkFlagRequired(flag); err != nil {
-			panic(err)
-		}
-	}
-	return cmd
 }

--- a/cmd/webhooks/deliveries_replay_bulk.go
+++ b/cmd/webhooks/deliveries_replay_bulk.go
@@ -51,14 +51,9 @@ func (c *ReplayDeliveriesController) Run(cmd *cobra.Command, _ []string) (fctl.R
 		return nil, err
 	}
 
-	statusValues := fctl.GetStringSlice(cmd, deliveryStatusFlag)
-	statuses := make([]DeliveryStatus, 0, len(statusValues))
-	for _, value := range statusValues {
-		status, err := deliveryStatus(strings.ToLower(value), true)
-		if err != nil {
-			return nil, err
-		}
-		statuses = append(statuses, status)
+	statuses, err := resolvedReplayStatuses(cmd)
+	if err != nil {
+		return nil, err
 	}
 
 	request := replayDeliveriesRequest{
@@ -87,6 +82,22 @@ func (c *ReplayDeliveriesController) Run(cmd *cobra.Command, _ []string) (fctl.R
 	return c, nil
 }
 
+func resolvedReplayStatuses(cmd *cobra.Command) ([]DeliveryStatus, error) {
+	values := fctl.GetStringSlice(cmd, deliveryStatusFlag)
+	if len(values) == 0 {
+		values = []string{string(DeliveryStatusFailed), string(DeliveryStatusPending)}
+	}
+	statuses := make([]DeliveryStatus, 0, len(values))
+	for _, value := range values {
+		status, err := deliveryStatus(strings.ToLower(value), true)
+		if err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
+}
+
 func (c *ReplayDeliveriesController) Render(cmd *cobra.Command, _ []string) error {
 	result := c.store.Result
 	pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Delivery replay page processed")
@@ -112,7 +123,7 @@ func NewReplayDeliveriesCommand() *cobra.Command {
 		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
 		fctl.WithStringFlag(createdAtFromFlag, "", "Replay deliveries created at or after this RFC3339 timestamp"),
 		fctl.WithStringFlag(createdAtToFlag, "", "Replay deliveries created at or before this RFC3339 timestamp"),
-		fctl.WithStringSliceFlag(deliveryStatusFlag, []string{string(DeliveryStatusFailed), string(DeliveryStatusPending)}, "Delivery statuses to replay (failed, pending)"),
+		fctl.WithStringSliceFlag(deliveryStatusFlag, []string{}, "Delivery statuses to replay (failed, pending; default: both)"),
 		fctl.WithStringSliceFlag(configIDFlag, []string{}, "Restrict replay to webhook config IDs"),
 		fctl.WithStringFlag(idempotencyKeyFlag, "", "Idempotency key for this replay request"),
 		fctl.WithCursorFlag(),

--- a/cmd/webhooks/deliveries_replay_bulk.go
+++ b/cmd/webhooks/deliveries_replay_bulk.go
@@ -1,0 +1,125 @@
+package webhooks
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type ReplayDeliveriesStore struct {
+	Result ReplayDeliveriesResult `json:"result"`
+}
+
+type ReplayDeliveriesController struct {
+	store *ReplayDeliveriesStore
+}
+
+func NewReplayDeliveriesController() *ReplayDeliveriesController {
+	return &ReplayDeliveriesController{store: &ReplayDeliveriesStore{}}
+}
+
+func (c *ReplayDeliveriesController) GetStore() *ReplayDeliveriesStore { return c.store }
+
+func (c *ReplayDeliveriesController) Run(cmd *cobra.Command, _ []string) (fctl.Renderable, error) {
+	if !fctl.CheckStackApprobation(cmd, "You are about to replay a page of webhook deliveries") {
+		return nil, fctl.ErrMissingApproval
+	}
+	createdAtFrom, err := fctl.GetDateTime(cmd, createdAtFromFlag)
+	if err != nil {
+		return nil, fmt.Errorf("parsing --%s: %w", createdAtFromFlag, err)
+	}
+	if createdAtFrom == nil {
+		return nil, fmt.Errorf("--%s is required", createdAtFromFlag)
+	}
+	createdAtTo, err := fctl.GetDateTime(cmd, createdAtToFlag)
+	if err != nil {
+		return nil, fmt.Errorf("parsing --%s: %w", createdAtToFlag, err)
+	}
+	pageSize, err := deliveryPageSize(cmd)
+	if err != nil {
+		return nil, err
+	}
+	cursor, err := fctl.GetCursor(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	statusValues := fctl.GetStringSlice(cmd, deliveryStatusFlag)
+	statuses := make([]DeliveryStatus, 0, len(statusValues))
+	for _, value := range statusValues {
+		status, err := deliveryStatus(strings.ToLower(value), true)
+		if err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, status)
+	}
+
+	request := replayDeliveriesRequest{
+		CreatedAtFrom: *createdAtFrom,
+		CreatedAtTo:   createdAtTo,
+		Statuses:      statuses,
+		ConfigIDs:     fctl.GetStringSlice(cmd, configIDFlag),
+		PageSize:      pageSize,
+	}
+	if cursor != "" {
+		request.Cursor = &cursor
+	}
+
+	api, err := authenticatedDeliveriesAPI(cmd)
+	if err != nil {
+		return nil, err
+	}
+	response, err := api.replayMany(cmd.Context(), fctl.GetString(cmd, idempotencyKeyFlag), request)
+	if err != nil {
+		return nil, fmt.Errorf("replaying deliveries: %w", err)
+	}
+	c.store.Result = response.Data
+	return c, nil
+}
+
+func (c *ReplayDeliveriesController) Render(cmd *cobra.Command, _ []string) error {
+	result := c.store.Result
+	pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Delivery replay page processed")
+	return pterm.DefaultTable.WithWriter(cmd.OutOrStdout()).WithData(pterm.TableData{
+		{"Replayed", strconv.Itoa(result.Replayed)},
+		{"Expedited", strconv.Itoa(result.Expedited)},
+		{"Skipped", strconv.Itoa(result.Skipped)},
+		{"Has more", strconv.FormatBool(result.HasMore)},
+		{"Next cursor", func() string {
+			if result.NextCursor == nil {
+				return ""
+			}
+			return *result.NextCursor
+		}()},
+		{"Created at to", result.CreatedAtTo.Format(time.RFC3339)},
+	}).Render()
+}
+
+func NewReplayDeliveriesCommand() *cobra.Command {
+	cmd := fctl.NewCommand("replay-bulk",
+		fctl.WithShortDescription("Replay a bounded page of failed or pending webhook deliveries"),
+		fctl.WithArgs(cobra.NoArgs),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithStringFlag(createdAtFromFlag, "", "Replay deliveries created at or after this RFC3339 timestamp"),
+		fctl.WithStringFlag(createdAtToFlag, "", "Replay deliveries created at or before this RFC3339 timestamp"),
+		fctl.WithStringSliceFlag(deliveryStatusFlag, []string{string(DeliveryStatusFailed), string(DeliveryStatusPending)}, "Delivery statuses to replay (failed, pending)"),
+		fctl.WithStringSliceFlag(configIDFlag, []string{}, "Restrict replay to webhook config IDs"),
+		fctl.WithStringFlag(idempotencyKeyFlag, "", "Idempotency key for this replay request"),
+		fctl.WithCursorFlag(),
+		fctl.WithPageSizeFlag(),
+		fctl.WithConfirmFlag(),
+		fctl.WithController[*ReplayDeliveriesStore](NewReplayDeliveriesController()),
+	)
+	for _, flag := range []string{createdAtFromFlag, idempotencyKeyFlag} {
+		if err := cmd.MarkFlagRequired(flag); err != nil {
+			panic(err)
+		}
+	}
+	return cmd
+}

--- a/cmd/webhooks/deliveries_show.go
+++ b/cmd/webhooks/deliveries_show.go
@@ -1,0 +1,50 @@
+package webhooks
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type ShowDeliveryStore struct {
+	Delivery Delivery `json:"delivery"`
+}
+
+type ShowDeliveryController struct {
+	store *ShowDeliveryStore
+}
+
+func NewShowDeliveryController() *ShowDeliveryController {
+	return &ShowDeliveryController{store: &ShowDeliveryStore{}}
+}
+
+func (c *ShowDeliveryController) GetStore() *ShowDeliveryStore { return c.store }
+
+func (c *ShowDeliveryController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	api, err := authenticatedDeliveriesAPI(cmd)
+	if err != nil {
+		return nil, err
+	}
+	response, err := api.get(cmd.Context(), args[0])
+	if err != nil {
+		return nil, fmt.Errorf("getting delivery: %w", err)
+	}
+	c.store.Delivery = response.Data
+	return c, nil
+}
+
+func (c *ShowDeliveryController) Render(cmd *cobra.Command, _ []string) error {
+	return renderDelivery(cmd, c.store.Delivery)
+}
+
+func NewShowDeliveryCommand() *cobra.Command {
+	return fctl.NewCommand("show <delivery-id>",
+		fctl.WithAliases("get"),
+		fctl.WithShortDescription("Show a webhook delivery, including its payload"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithController[*ShowDeliveryStore](NewShowDeliveryController()),
+	)
+}

--- a/cmd/webhooks/deliveries_test.go
+++ b/cmd/webhooks/deliveries_test.go
@@ -1,0 +1,209 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeliveriesAPIReadEndpoints(t *testing.T) {
+	from := time.Date(2026, time.July, 1, 10, 0, 0, 0, time.UTC)
+	to := from.Add(time.Hour)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/webhooks/deliveries":
+			if r.Method != http.MethodGet {
+				t.Fatalf("method = %s, want GET", r.Method)
+			}
+			wantQuery := map[string]string{
+				"configId":      "config-1",
+				"status":        "failed",
+				"createdAtFrom": from.Format(time.RFC3339),
+				"createdAtTo":   to.Format(time.RFC3339),
+				"cursor":        "cursor-1",
+				"pageSize":      "25",
+			}
+			for key, want := range wantQuery {
+				if got := r.URL.Query().Get(key); got != want {
+					t.Errorf("query %s = %q, want %q", key, got, want)
+				}
+			}
+			_, _ = w.Write([]byte(`{"cursor":{"pageSize":25,"hasMore":true,"next":"cursor-2","data":[{"id":"delivery-1","eventID":"event-1","configID":"config-1","eventType":"ledger.committed_transactions","status":"failed","attemptCount":3,"replayGeneration":0,"createdAt":"2026-07-01T10:00:00Z","updatedAt":"2026-07-01T10:01:00Z"}]}}`))
+		case "/api/webhooks/deliveries/delivery-1":
+			_, _ = w.Write([]byte(`{"data":{"id":"delivery-1","eventID":"event-1","configID":"config-1","eventType":"ledger.committed_transactions","payload":"{}","status":"failed","attemptCount":3,"replayGeneration":0,"createdAt":"2026-07-01T10:00:00Z","updatedAt":"2026-07-01T10:01:00Z"}}`))
+		case "/api/webhooks/deliveries/delivery-1/attempts":
+			if got := r.URL.Query().Get("cursor"); got != "attempt-cursor" {
+				t.Errorf("cursor = %q, want attempt-cursor", got)
+			}
+			if got := r.URL.Query().Get("pageSize"); got != "10" {
+				t.Errorf("pageSize = %q, want 10", got)
+			}
+			_, _ = w.Write([]byte(`{"cursor":{"pageSize":10,"hasMore":false,"data":[{"id":"attempt-1","deliveryID":"delivery-1","attemptNumber":1,"replayGeneration":0,"endpoint":"https://example.com/hook","outcome":"permanent_failure","statusCode":404,"durationMillis":12,"createdAt":"2026-07-01T10:01:00Z"}]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	api := newDeliveriesAPI(server.URL, server.Client())
+	list, err := api.list(context.Background(), listDeliveriesParams{
+		ConfigID:      "config-1",
+		Status:        DeliveryStatusFailed,
+		CreatedAtFrom: &from,
+		CreatedAtTo:   &to,
+		Cursor:        "cursor-1",
+		PageSize:      25,
+	})
+	if err != nil {
+		t.Fatalf("list() error = %v", err)
+	}
+	if len(list.Cursor.Data) != 1 || list.Cursor.Data[0].ID != "delivery-1" || list.Cursor.Next == nil || *list.Cursor.Next != "cursor-2" {
+		t.Fatalf("list() response = %#v", list)
+	}
+
+	delivery, err := api.get(context.Background(), "delivery-1")
+	if err != nil {
+		t.Fatalf("get() error = %v", err)
+	}
+	if delivery.Data.Payload != "{}" {
+		t.Fatalf("get() payload = %q, want {}", delivery.Data.Payload)
+	}
+
+	attempts, err := api.attempts(context.Background(), "delivery-1", "attempt-cursor", 10)
+	if err != nil {
+		t.Fatalf("attempts() error = %v", err)
+	}
+	if len(attempts.Cursor.Data) != 1 || attempts.Cursor.Data[0].StatusCode != 404 || attempts.Cursor.Data[0].DurationMillis != 12 {
+		t.Fatalf("attempts() response = %#v", attempts)
+	}
+}
+
+func TestDeliveriesAPIReplayEndpoints(t *testing.T) {
+	from := time.Date(2026, time.July, 1, 10, 0, 0, 0, time.UTC)
+	to := from.Add(24 * time.Hour)
+	var calls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/webhooks/deliveries/delivery-1/replay":
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			if got := r.Header.Get("Idempotency-Key"); got != "individual-key" {
+				t.Fatalf("Idempotency-Key = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":{"id":"delivery-1","eventID":"event-1","configID":"config-1","eventType":"event","status":"pending","attemptCount":0,"replayGeneration":1,"createdAt":"2026-07-01T10:00:00Z","updatedAt":"2026-07-01T10:02:00Z"}}`))
+		case "/api/webhooks/deliveries/replay":
+			if got := r.Header.Get("Idempotency-Key"); got != "bulk-key" {
+				t.Fatalf("Idempotency-Key = %q", got)
+			}
+			var body replayDeliveriesRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if !body.CreatedAtFrom.Equal(from) || body.CreatedAtTo == nil || !body.CreatedAtTo.Equal(to) {
+				t.Errorf("window = %s..%v, want %s..%s", body.CreatedAtFrom, body.CreatedAtTo, from, to)
+			}
+			if !reflect.DeepEqual(body.Statuses, []DeliveryStatus{DeliveryStatusFailed, DeliveryStatusPending}) {
+				t.Errorf("statuses = %v", body.Statuses)
+			}
+			if !reflect.DeepEqual(body.ConfigIDs, []string{"config-1"}) || body.Cursor == nil || *body.Cursor != "cursor-1" || body.PageSize != 1000 {
+				t.Errorf("bulk body = %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"data":{"replayed":2,"expedited":1,"skipped":0,"hasMore":true,"nextCursor":"cursor-2","createdAtTo":"2026-07-02T10:00:00Z"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	api := newDeliveriesAPI(server.URL, server.Client())
+	replayed, err := api.replay(context.Background(), "delivery-1", "individual-key")
+	if err != nil {
+		t.Fatalf("replay() error = %v", err)
+	}
+	if replayed.Data.Status != DeliveryStatusPending || replayed.Data.ReplayGeneration != 1 {
+		t.Fatalf("replay() response = %#v", replayed)
+	}
+
+	cursor := "cursor-1"
+	bulk, err := api.replayMany(context.Background(), "bulk-key", replayDeliveriesRequest{
+		CreatedAtFrom: from,
+		CreatedAtTo:   &to,
+		Statuses:      []DeliveryStatus{DeliveryStatusFailed, DeliveryStatusPending},
+		ConfigIDs:     []string{"config-1"},
+		Cursor:        &cursor,
+		PageSize:      1000,
+	})
+	if err != nil {
+		t.Fatalf("replayMany() error = %v", err)
+	}
+	if bulk.Data.Replayed != 2 || bulk.Data.NextCursor == nil || *bulk.Data.NextCursor != "cursor-2" {
+		t.Fatalf("replayMany() response = %#v", bulk)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}
+
+func TestDeliveriesAPIIncludesErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"errorCode":"VALIDATION","errorMessage":"delivery cannot be replayed"}`))
+	}))
+	defer server.Close()
+
+	_, err := newDeliveriesAPI(server.URL, server.Client()).replay(context.Background(), "delivery-1", "key")
+	if err == nil {
+		t.Fatal("replay() expected error")
+	}
+	for _, want := range []string{"status 409", "delivery cannot be replayed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want substring %q", err, want)
+		}
+	}
+}
+
+func TestDeliveriesCommandExposesAllEndpoints(t *testing.T) {
+	cmd := NewDeliveriesCommand()
+	for _, name := range []string{"list", "show", "attempts", "replay", "replay-bulk"} {
+		child, _, err := cmd.Find([]string{name})
+		if err != nil || child == cmd || child.Name() != name {
+			t.Errorf("command %q not found", name)
+		}
+	}
+	for _, name := range []string{"replay", "replay-bulk"} {
+		child, _, _ := cmd.Find([]string{name})
+		if child.Flag(idempotencyKeyFlag) == nil {
+			t.Errorf("command %q is missing --%s", name, idempotencyKeyFlag)
+		}
+	}
+}
+
+func TestWebhooksCommandExposesConfigEndpoints(t *testing.T) {
+	cmd := NewCommand()
+	for _, name := range []string{"create", "list", "update", "test", "activate", "deactivate", "delete", "change-secret", "deliveries"} {
+		child, _, err := cmd.Find([]string{name})
+		if err != nil || child == cmd || child.Name() != name {
+			t.Errorf("command %q not found", name)
+		}
+	}
+}
+
+func TestDeliveryStatusValidation(t *testing.T) {
+	if _, err := deliveryStatus("succeeded", true); err == nil {
+		t.Fatal("bulk replay accepted succeeded status")
+	}
+	if status, err := deliveryStatus("succeeded", false); err != nil || status != DeliveryStatusSucceeded {
+		t.Fatalf("list status = %q, err = %v", status, err)
+	}
+}

--- a/cmd/webhooks/deliveries_test.go
+++ b/cmd/webhooks/deliveries_test.go
@@ -248,3 +248,26 @@ func TestRequiredIdempotencyKeyRejectsMissingValue(t *testing.T) {
 		t.Fatal("requiredIdempotencyKey() expected an error")
 	}
 }
+
+func TestReplayStatusesUseEnvironmentBeforeDefaults(t *testing.T) {
+	t.Setenv("STATUS", "failed")
+	statuses, err := resolvedReplayStatuses(NewReplayDeliveriesCommand())
+	if err != nil {
+		t.Fatalf("resolvedReplayStatuses() error = %v", err)
+	}
+	if !reflect.DeepEqual(statuses, []DeliveryStatus{DeliveryStatusFailed}) {
+		t.Fatalf("statuses = %v, want [failed]", statuses)
+	}
+}
+
+func TestReplayStatusesDefaultToFailedAndPending(t *testing.T) {
+	t.Setenv("STATUS", "")
+	statuses, err := resolvedReplayStatuses(NewReplayDeliveriesCommand())
+	if err != nil {
+		t.Fatalf("resolvedReplayStatuses() error = %v", err)
+	}
+	want := []DeliveryStatus{DeliveryStatusFailed, DeliveryStatusPending}
+	if !reflect.DeepEqual(statuses, want) {
+		t.Fatalf("statuses = %v, want %v", statuses, want)
+	}
+}

--- a/cmd/webhooks/deliveries_test.go
+++ b/cmd/webhooks/deliveries_test.go
@@ -199,6 +199,20 @@ func TestWebhooksCommandExposesConfigEndpoints(t *testing.T) {
 	}
 }
 
+func TestWebhooksCommandAliasesDoNotConflict(t *testing.T) {
+	cmd := NewCommand()
+
+	deleteCommand, _, err := cmd.Find([]string{"del"})
+	if err != nil || deleteCommand.Name() != "delete" {
+		t.Fatalf("alias del resolved to %q, want delete (err = %v)", deleteCommand.Name(), err)
+	}
+
+	deliveriesCommand, _, err := cmd.Find([]string{"dlvs"})
+	if err != nil || deliveriesCommand.Name() != "deliveries" {
+		t.Fatalf("alias dlvs resolved to %q, want deliveries (err = %v)", deliveriesCommand.Name(), err)
+	}
+}
+
 func TestDeliveryStatusValidation(t *testing.T) {
 	if _, err := deliveryStatus("succeeded", true); err == nil {
 		t.Fatal("bulk replay accepted succeeded status")

--- a/cmd/webhooks/deliveries_test.go
+++ b/cmd/webhooks/deliveries_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
 )
 
 func TestDeliveriesAPIReadEndpoints(t *testing.T) {
@@ -219,5 +221,30 @@ func TestDeliveryStatusValidation(t *testing.T) {
 	}
 	if status, err := deliveryStatus("succeeded", false); err != nil || status != DeliveryStatusSucceeded {
 		t.Fatalf("list status = %q, err = %v", status, err)
+	}
+}
+
+func TestReplayCommandsResolveRequiredValuesFromEnvironment(t *testing.T) {
+	t.Setenv("IDEMPOTENCY_KEY", "environment-key")
+	t.Setenv("CREATED_AT_FROM", "2026-08-01T10:00:00Z")
+
+	individual := NewReplayDeliveryCommand()
+	key, err := requiredIdempotencyKey(individual)
+	if err != nil || key != "environment-key" {
+		t.Fatalf("idempotency key = %q, err = %v", key, err)
+	}
+
+	bulk := NewReplayDeliveriesCommand()
+	from, err := fctl.GetDateTime(bulk, createdAtFromFlag)
+	if err != nil || from == nil || from.Format(time.RFC3339) != "2026-08-01T10:00:00Z" {
+		t.Fatalf("created-at-from = %v, err = %v", from, err)
+	}
+}
+
+func TestRequiredIdempotencyKeyRejectsMissingValue(t *testing.T) {
+	t.Setenv("IDEMPOTENCY_KEY", "")
+	_, err := requiredIdempotencyKey(NewReplayDeliveryCommand())
+	if err == nil {
+		t.Fatal("requiredIdempotencyKey() expected an error")
 	}
 }

--- a/cmd/webhooks/list.go
+++ b/cmd/webhooks/list.go
@@ -50,6 +50,12 @@ func (c *ListWebhookController) Run(cmd *cobra.Command, args []string) (fctl.Ren
 		return nil, err
 	}
 	request := operations.GetManyConfigsRequest{}
+	if configID := fctl.GetString(cmd, configIDFlag); configID != "" {
+		request.ID = &configID
+	}
+	if endpoint := fctl.GetString(cmd, endpointFlag); endpoint != "" {
+		request.Endpoint = &endpoint
+	}
 	response, err := stackClient.Webhooks.V1.GetManyConfigs(cmd.Context(), request)
 	if err != nil {
 		return nil, fmt.Errorf("listing all config: %w", err)
@@ -88,10 +94,12 @@ func (c *ListWebhookController) Render(cmd *cobra.Command, args []string) error 
 
 func NewListCommand() *cobra.Command {
 	return fctl.NewCommand("list",
-		fctl.WithShortDescription("List all configs"),
+		fctl.WithShortDescription("List webhook configs"),
 		fctl.WithAliases("ls", "l"),
 		fctl.WithArgs(cobra.ExactArgs(0)),
 		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithStringFlag(configIDFlag, "", "Filter by config ID"),
+		fctl.WithStringFlag(endpointFlag, "", "Filter by endpoint URL"),
 		fctl.WithController[*ListWebhookStore](NewListWebhookController()),
 	)
 }

--- a/cmd/webhooks/root.go
+++ b/cmd/webhooks/root.go
@@ -13,6 +13,9 @@ func NewCommand() *cobra.Command {
 		fctl.WithChildCommands(
 			NewCreateCommand(),
 			NewListCommand(),
+			NewUpdateCommand(),
+			NewTestCommand(),
+			NewDeliveriesCommand(),
 			NewDeactivateCommand(),
 			NewActivateCommand(),
 			NewDeleteCommand(),

--- a/cmd/webhooks/test.go
+++ b/cmd/webhooks/test.go
@@ -1,0 +1,80 @@
+package webhooks
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"github.com/formancehq/formance-sdk-go/v4/pkg/models/operations"
+	webhooksmodels "github.com/formancehq/formance-sdk-go/v4/pkg/models/webhooks"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type TestWebhookStore struct {
+	Attempt webhooksmodels.Attempt `json:"attempt"`
+}
+
+type TestWebhookController struct {
+	store *TestWebhookStore
+}
+
+func NewTestWebhookController() *TestWebhookController {
+	return &TestWebhookController{store: &TestWebhookStore{}}
+}
+
+func (c *TestWebhookController) GetStore() *TestWebhookStore { return c.store }
+
+func (c *TestWebhookController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	_, profile, profileName, relyingParty, err := fctl.LoadAndAuthenticateCurrentProfile(cmd)
+	if err != nil {
+		return nil, err
+	}
+	stackClient, err := fctl.NewStackClientFromFlags(cmd, relyingParty, fctl.NewPTermDialog(), profileName, *profile)
+	if err != nil {
+		return nil, err
+	}
+	if !fctl.CheckStackApprobation(cmd, "You are about to send a test event to webhook config %s", args[0]) {
+		return nil, fctl.ErrMissingApproval
+	}
+	response, err := stackClient.Webhooks.V1.TestConfig(cmd.Context(), operations.TestConfigRequest{ID: args[0]})
+	if err != nil {
+		return nil, fmt.Errorf("testing config: %w", err)
+	}
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("testing config: unexpected status code %d", response.StatusCode)
+	}
+	if response.AttemptResponse == nil {
+		return nil, fmt.Errorf("testing config: empty response")
+	}
+	c.store.Attempt = response.AttemptResponse.Attempt
+	return c, nil
+}
+
+func (c *TestWebhookController) Render(cmd *cobra.Command, _ []string) error {
+	attempt := c.store.Attempt
+	pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Test event sent")
+	return pterm.DefaultTable.WithWriter(cmd.OutOrStdout()).WithData(pterm.TableData{
+		{"Attempt ID", attempt.ID},
+		{"Webhook ID", attempt.WebhookID},
+		{"Status", attempt.Status},
+		{"Status code", strconv.FormatInt(attempt.StatusCode, 10)},
+		{"Retry attempt", strconv.FormatInt(attempt.RetryAttempt, 10)},
+		{"Next retry after", optionalTime(attempt.NextRetryAfter)},
+		{"Created at", attempt.CreatedAt.Format(time.RFC3339)},
+		{"Updated at", attempt.UpdatedAt.Format(time.RFC3339)},
+	}).Render()
+}
+
+func NewTestCommand() *cobra.Command {
+	return fctl.NewCommand("test <config-id>",
+		fctl.WithShortDescription("Send a test event to a webhook config"),
+		fctl.WithConfirmFlag(),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithController[*TestWebhookStore](NewTestWebhookController()),
+	)
+}

--- a/cmd/webhooks/update.go
+++ b/cmd/webhooks/update.go
@@ -1,0 +1,83 @@
+package webhooks
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"github.com/formancehq/formance-sdk-go/v4/pkg/models/operations"
+	webhooksmodels "github.com/formancehq/formance-sdk-go/v4/pkg/models/webhooks"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type UpdateWebhookStore struct {
+	Success bool `json:"success"`
+}
+
+type UpdateWebhookController struct {
+	store *UpdateWebhookStore
+}
+
+func NewUpdateWebhookController() *UpdateWebhookController {
+	return &UpdateWebhookController{store: &UpdateWebhookStore{}}
+}
+
+func (c *UpdateWebhookController) GetStore() *UpdateWebhookStore { return c.store }
+
+func (c *UpdateWebhookController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	_, profile, profileName, relyingParty, err := fctl.LoadAndAuthenticateCurrentProfile(cmd)
+	if err != nil {
+		return nil, err
+	}
+	stackClient, err := fctl.NewStackClientFromFlags(cmd, relyingParty, fctl.NewPTermDialog(), profileName, *profile)
+	if err != nil {
+		return nil, err
+	}
+	if !fctl.CheckStackApprobation(cmd, "You are about to update webhook config %s", args[0]) {
+		return nil, fctl.ErrMissingApproval
+	}
+	if _, err := url.ParseRequestURI(args[1]); err != nil {
+		return nil, fmt.Errorf("invalid endpoint URL: %w", err)
+	}
+
+	secret := fctl.GetString(cmd, secretFlag)
+	request := operations.UpdateConfigRequest{
+		ID: args[0],
+		ConfigUser: webhooksmodels.ConfigUser{
+			Endpoint:   args[1],
+			EventTypes: args[2:],
+		},
+	}
+	if cmd.Flags().Changed(secretFlag) {
+		request.ConfigUser.Secret = &secret
+	}
+	response, err := stackClient.Webhooks.V1.UpdateConfig(cmd.Context(), request)
+	if err != nil {
+		return nil, fmt.Errorf("updating config: %w", err)
+	}
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("updating config: unexpected status code %d", response.StatusCode)
+	}
+	c.store.Success = true
+	return c, nil
+}
+
+func (c *UpdateWebhookController) Render(cmd *cobra.Command, _ []string) error {
+	pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Config updated successfully")
+	return nil
+}
+
+func NewUpdateCommand() *cobra.Command {
+	return fctl.NewCommand("update <config-id> <endpoint> [<event-type>...]",
+		fctl.WithShortDescription("Update a webhook config. At least one event type is required."),
+		fctl.WithAliases("up"),
+		fctl.WithConfirmFlag(),
+		fctl.WithArgs(cobra.MinimumNArgs(3)),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithStringFlag(secretFlag, "", "Set the webhook signing secret. If omitted, Webhooks generates a new one"),
+		fctl.WithController[*UpdateWebhookStore](NewUpdateWebhookController()),
+	)
+}

--- a/cmd/webhooks/update.go
+++ b/cmd/webhooks/update.go
@@ -43,17 +43,7 @@ func (c *UpdateWebhookController) Run(cmd *cobra.Command, args []string) (fctl.R
 		return nil, fmt.Errorf("invalid endpoint URL: %w", err)
 	}
 
-	secret := fctl.GetString(cmd, secretFlag)
-	request := operations.UpdateConfigRequest{
-		ID: args[0],
-		ConfigUser: webhooksmodels.ConfigUser{
-			Endpoint:   args[1],
-			EventTypes: args[2:],
-		},
-	}
-	if cmd.Flags().Changed(secretFlag) {
-		request.ConfigUser.Secret = &secret
-	}
+	request := newUpdateConfigRequest(cmd, args)
 	response, err := stackClient.Webhooks.V1.UpdateConfig(cmd.Context(), request)
 	if err != nil {
 		return nil, fmt.Errorf("updating config: %w", err)
@@ -63,6 +53,21 @@ func (c *UpdateWebhookController) Run(cmd *cobra.Command, args []string) (fctl.R
 	}
 	c.store.Success = true
 	return c, nil
+}
+
+func newUpdateConfigRequest(cmd *cobra.Command, args []string) operations.UpdateConfigRequest {
+	request := operations.UpdateConfigRequest{
+		ID: args[0],
+		ConfigUser: webhooksmodels.ConfigUser{
+			Endpoint:   args[1],
+			EventTypes: args[2:],
+		},
+	}
+	secret := fctl.GetString(cmd, secretFlag)
+	if cmd.Flags().Changed(secretFlag) || secret != "" {
+		request.ConfigUser.Secret = &secret
+	}
+	return request
 }
 
 func (c *UpdateWebhookController) Render(cmd *cobra.Command, _ []string) error {

--- a/cmd/webhooks/update_test.go
+++ b/cmd/webhooks/update_test.go
@@ -1,0 +1,36 @@
+package webhooks
+
+import "testing"
+
+func TestNewUpdateConfigRequestIncludesSecretFromEnvironment(t *testing.T) {
+	t.Setenv("SECRET", "environment-secret")
+	cmd := NewUpdateCommand()
+
+	request := newUpdateConfigRequest(cmd, []string{"config-1", "https://example.com", "event"})
+	if request.ConfigUser.Secret == nil || *request.ConfigUser.Secret != "environment-secret" {
+		t.Fatalf("secret = %v, want environment-secret", request.ConfigUser.Secret)
+	}
+}
+
+func TestNewUpdateConfigRequestSecretFlagOverridesEnvironment(t *testing.T) {
+	t.Setenv("SECRET", "environment-secret")
+	cmd := NewUpdateCommand()
+	if err := cmd.Flags().Set(secretFlag, "flag-secret"); err != nil {
+		t.Fatalf("set secret flag: %v", err)
+	}
+
+	request := newUpdateConfigRequest(cmd, []string{"config-1", "https://example.com", "event"})
+	if request.ConfigUser.Secret == nil || *request.ConfigUser.Secret != "flag-secret" {
+		t.Fatalf("secret = %v, want flag-secret", request.ConfigUser.Secret)
+	}
+}
+
+func TestNewUpdateConfigRequestOmitsUnspecifiedSecret(t *testing.T) {
+	t.Setenv("SECRET", "")
+	cmd := NewUpdateCommand()
+
+	request := newUpdateConfigRequest(cmd, []string{"config-1", "https://example.com", "event"})
+	if request.ConfigUser.Secret != nil {
+		t.Fatalf("secret = %q, want nil", *request.ConfigUser.Secret)
+	}
+}


### PR DESCRIPTION
## Summary

- add `webhooks update` and `webhooks test` commands
- add config ID and endpoint filters to `webhooks list`
- add delivery list, detail, attempt history, individual replay, and bulk replay commands
- support delivery filters, cursor pagination, replay windows, confirmations, and idempotency keys
- use the authenticated stack HTTP client for delivery endpoints that are not yet exposed by the aggregate Go SDK

## User impact

Operators can inspect durable webhook delivery state and attempt history directly from `fctl`, then replay eligible deliveries individually or in bounded bulk pages. The existing webhook config API is also fully represented by CLI commands.

## Validation

- `go test ./...`
- `go vet ./cmd/webhooks`
- `nix develop --impure --command golangci-lint run --timeout 5m`