### PR TITLE
feat(reconciliation): add Ledger Clarity commands

### DIFF
--- a/cmd/reconciliation/alerts/root.go
+++ b/cmd/reconciliation/alerts/root.go
@@ -1,0 +1,216 @@
+package alerts
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"github.com/formancehq/fctl/v3/cmd/reconciliation/internal/clarity"
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+const queryFlag = "query"
+
+func NewCommand() *cobra.Command {
+	return fctl.NewCommand("alerts",
+		fctl.WithAliases("alert"),
+		fctl.WithShortDescription("Manage Ledger Clarity alerts"),
+		fctl.WithChildCommands(
+			newListCommand(),
+			newGetCommand(),
+			newEventsCommand(),
+			newAckCommand(),
+			newResolveCommand(),
+			newAcceptCommand(),
+			newSnoozeCommand(),
+			newUnsnoozeCommand(),
+		),
+	)
+}
+
+func newListCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, _ []string, client *clarity.Client) (clarity.Store, error) {
+		query, err := clarity.PaginationQuery(cmd)
+		if err != nil {
+			return nil, err
+		}
+		var body any
+		if query.Get("cursor") == "" {
+			body, err = clarity.QueryBody(cmd, queryFlag)
+			if err != nil {
+				return nil, err
+			}
+		}
+		var response clarity.CursorResponse[clarity.Alert]
+		if err := client.Do(cmd, http.MethodGet, "/alerts", query, body, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"alerts": response.Cursor.Data, "cursor": clarity.Page(response.Cursor)}, nil
+	}, renderAlerts)
+	return fctl.NewCommand("list",
+		fctl.WithAliases("ls", "l"),
+		fctl.WithShortDescription("List alerts"),
+		fctl.WithArgs(cobra.NoArgs),
+		fctl.WithCursorFlag(),
+		fctl.WithPageSizeFlag(),
+		fctl.WithStringFlag(queryFlag, "", "Query-builder expression as JSON"),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func newGetCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		var response clarity.DataResponse[clarity.Alert]
+		if err := client.Do(cmd, http.MethodGet, alertPath(args[0]), nil, nil, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"alert": response.Data}, nil
+	}, nil)
+	return fctl.NewCommand("get <alertID>",
+		fctl.WithAliases("show", "sh", "s"),
+		fctl.WithShortDescription("Get an alert"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func newEventsCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		query, err := clarity.PaginationQuery(cmd)
+		if err != nil {
+			return nil, err
+		}
+		var response clarity.CursorResponse[clarity.AlertEvent]
+		if err := client.Do(cmd, http.MethodGet, alertPath(args[0])+"/events", query, nil, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"events": response.Cursor.Data, "cursor": clarity.Page(response.Cursor)}, nil
+	}, renderEvents)
+	return fctl.NewCommand("events <alertID>",
+		fctl.WithShortDescription("List an alert's append-only event timeline"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithCursorFlag(),
+		fctl.WithPageSizeFlag(),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func newAckCommand() *cobra.Command {
+	return newTransitionCommand("ack <alertID>", "Acknowledge an alert", "ack", []string{"by"}, func(cmd *cobra.Command) map[string]any {
+		return optionalNote(map[string]any{"by": fctl.GetString(cmd, "by")}, cmd)
+	},
+		fctl.WithStringFlag("by", "", "Actor acknowledging the alert"),
+		fctl.WithStringFlag("note", "", "Optional acknowledgement note"),
+	)
+}
+
+func newResolveCommand() *cobra.Command {
+	return newTransitionCommand("resolve <alertID>", "Resolve an alert as fixed by booking", "resolve", []string{"by"}, func(cmd *cobra.Command) map[string]any {
+		body := optionalNote(map[string]any{"by": fctl.GetString(cmd, "by")}, cmd)
+		refs, _ := cmd.Flags().GetStringArray("transaction-ref")
+		if len(refs) > 0 {
+			body["transactionRefs"] = refs
+		}
+		return body
+	},
+		fctl.WithStringFlag("by", "", "Actor resolving the alert"),
+		fctl.WithStringFlag("note", "", "Optional resolution note"),
+		fctl.WithStringArrayFlag("transaction-ref", nil, "Related transaction reference (repeatable)"),
+	)
+}
+
+func newAcceptCommand() *cobra.Command {
+	return newTransitionCommand("accept <alertID>", "Accept an alert as a business exception", "accept", []string{"by", "note"}, func(cmd *cobra.Command) map[string]any {
+		return map[string]any{"by": fctl.GetString(cmd, "by"), "note": fctl.GetString(cmd, "note")}
+	},
+		fctl.WithStringFlag("by", "", "Actor accepting the alert"),
+		fctl.WithStringFlag("note", "", "Required business justification"),
+	)
+}
+
+func newSnoozeCommand() *cobra.Command {
+	return newTransitionCommand("snooze <alertID>", "Snooze an alert's notifications", "snooze", []string{"by", "until"}, func(cmd *cobra.Command) map[string]any {
+		return optionalNote(map[string]any{"by": fctl.GetString(cmd, "by"), "until": fctl.GetString(cmd, "until")}, cmd)
+	},
+		fctl.WithStringFlag("by", "", "Actor snoozing the alert"),
+		fctl.WithStringFlag("until", "", "Future snooze deadline (RFC3339)"),
+		fctl.WithStringFlag("note", "", "Optional snooze note"),
+	)
+}
+
+func newUnsnoozeCommand() *cobra.Command {
+	return newTransitionCommand("unsnooze <alertID>", "Lift an alert snooze early", "unsnooze", []string{"by"}, func(cmd *cobra.Command) map[string]any {
+		return map[string]any{"by": fctl.GetString(cmd, "by")}
+	}, fctl.WithStringFlag("by", "", "Actor lifting the snooze"))
+}
+
+func newTransitionCommand(use, description, endpoint string, required []string, body func(*cobra.Command) map[string]any, options ...fctl.CommandOption) *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		if !fctl.CheckStackApprobation(cmd, "You are about to %s alert '%s'", endpoint, args[0]) {
+			return nil, fctl.ErrMissingApproval
+		}
+		var response clarity.DataResponse[clarity.Alert]
+		if err := client.Do(cmd, http.MethodPost, alertPath(args[0])+"/"+endpoint, nil, body(cmd), &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"alert": response.Data}, nil
+	}, nil)
+	baseOptions := []fctl.CommandOption{
+		fctl.WithShortDescription(description),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithConfirmFlag(),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithController[clarity.Store](controller),
+	}
+	cmd := fctl.NewCommand(use, append(baseOptions, options...)...)
+	for _, flag := range required {
+		_ = cmd.MarkFlagRequired(flag)
+	}
+	return cmd
+}
+
+func optionalNote(body map[string]any, cmd *cobra.Command) map[string]any {
+	if note := fctl.GetString(cmd, "note"); note != "" {
+		body["note"] = note
+	}
+	return body
+}
+
+func alertPath(id string) string { return "/alerts/" + clarity.ResourcePath(id) }
+
+func renderAlerts(cmd *cobra.Command, store clarity.Store) error {
+	alerts := store["alerts"].([]clarity.Alert)
+	rows := pterm.TableData{{"ID", "RuleID", "Fingerprint", "Period", "Status", "Severity", "Occurrences", "LastSeenAt"}}
+	for _, alert := range alerts {
+		rows = append(rows, []string{alert.ID, alert.RuleID, alert.Fingerprint, alert.PeriodID, alert.Status, alert.Severity, fmt.Sprint(alert.OccurrenceCount), alert.LastSeenAt})
+	}
+	if err := pterm.DefaultTable.WithHasHeader().WithWriter(cmd.OutOrStdout()).WithData(rows).Render(); err != nil {
+		return err
+	}
+	cursor := store["cursor"].(clarity.PageCursor)
+	return fctl.RenderCursor(cmd.OutOrStdout(), fctl.Cursor{HasMore: cursor.HasMore, PageSize: cursor.PageSize, Next: cursor.Next, Previous: cursor.Previous})
+}
+
+func renderEvents(cmd *cobra.Command, store clarity.Store) error {
+	events := store["events"].([]clarity.AlertEvent)
+	rows := pterm.TableData{{"ID", "Type", "Previous", "NewStatus", "At", "Reopen", "Notify", "EvaluationID"}}
+	for _, event := range events {
+		previous, evaluationID := "", ""
+		if event.Previous != nil {
+			previous = *event.Previous
+		}
+		if event.EvaluationID != nil {
+			evaluationID = *event.EvaluationID
+		}
+		rows = append(rows, []string{event.ID, event.Type, previous, event.NewStatus, event.At, fmt.Sprint(event.IsReopen), fmt.Sprint(event.Notify), evaluationID})
+	}
+	if err := pterm.DefaultTable.WithHasHeader().WithWriter(cmd.OutOrStdout()).WithData(rows).Render(); err != nil {
+		return err
+	}
+	cursor := store["cursor"].(clarity.PageCursor)
+	return fctl.RenderCursor(cmd.OutOrStdout(), fctl.Cursor{HasMore: cursor.HasMore, PageSize: cursor.PageSize, Next: cursor.Next, Previous: cursor.Previous})
+}

--- a/cmd/reconciliation/evaluations/root.go
+++ b/cmd/reconciliation/evaluations/root.go
@@ -1,0 +1,82 @@
+package evaluations
+
+import (
+	"net/http"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"github.com/formancehq/fctl/v3/cmd/reconciliation/internal/clarity"
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+const queryFlag = "query"
+
+func NewCommand() *cobra.Command {
+	return fctl.NewCommand("evaluations",
+		fctl.WithAliases("evaluation", "evals"),
+		fctl.WithShortDescription("Inspect Ledger Clarity evaluations"),
+		fctl.WithChildCommands(newListCommand(), newGetCommand()),
+	)
+}
+
+func newListCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, _ []string, client *clarity.Client) (clarity.Store, error) {
+		query, err := clarity.PaginationQuery(cmd)
+		if err != nil {
+			return nil, err
+		}
+		var body any
+		if query.Get("cursor") == "" {
+			body, err = clarity.QueryBody(cmd, queryFlag)
+			if err != nil {
+				return nil, err
+			}
+		}
+		var response clarity.CursorResponse[clarity.Evaluation]
+		if err := client.Do(cmd, http.MethodGet, "/evaluations", query, body, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"evaluations": response.Cursor.Data, "cursor": clarity.Page(response.Cursor)}, nil
+	}, renderEvaluations)
+	return fctl.NewCommand("list",
+		fctl.WithAliases("ls", "l"),
+		fctl.WithShortDescription("List evaluations"),
+		fctl.WithArgs(cobra.NoArgs),
+		fctl.WithCursorFlag(),
+		fctl.WithPageSizeFlag(),
+		fctl.WithStringFlag(queryFlag, "", "Query-builder expression as JSON"),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func newGetCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		var response clarity.DataResponse[clarity.Evaluation]
+		path := "/evaluations/" + clarity.ResourcePath(args[0])
+		if err := client.Do(cmd, http.MethodGet, path, nil, nil, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"evaluation": response.Data}, nil
+	}, nil)
+	return fctl.NewCommand("get <evaluationID>",
+		fctl.WithAliases("show", "sh", "s"),
+		fctl.WithShortDescription("Get an evaluation"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func renderEvaluations(cmd *cobra.Command, store clarity.Store) error {
+	evaluations := store["evaluations"].([]clarity.Evaluation)
+	rows := pterm.TableData{{"ID", "RuleID", "Result", "StartedAt", "EndedAt", "CostUnits"}}
+	for _, evaluation := range evaluations {
+		rows = append(rows, []string{evaluation.ID, evaluation.RuleID, evaluation.Result, evaluation.StartedAt, evaluation.EndedAt, pterm.Sprintf("%d", evaluation.CostUnits)})
+	}
+	if err := pterm.DefaultTable.WithHasHeader().WithWriter(cmd.OutOrStdout()).WithData(rows).Render(); err != nil {
+		return err
+	}
+	cursor := store["cursor"].(clarity.PageCursor)
+	return fctl.RenderCursor(cmd.OutOrStdout(), fctl.Cursor{HasMore: cursor.HasMore, PageSize: cursor.PageSize, Next: cursor.Next, Previous: cursor.Previous})
+}

--- a/cmd/reconciliation/internal/clarity/client.go
+++ b/cmd/reconciliation/internal/clarity/client.go
@@ -36,9 +36,15 @@ func NewClient(cmd *cobra.Command) (*Client, error) {
 func (c *Client) Do(cmd *cobra.Command, method, requestPath string, query url.Values, body any, response any) error {
 	var reader io.Reader
 	if body != nil {
-		encoded, err := json.Marshal(body)
-		if err != nil {
-			return fmt.Errorf("encoding request: %w", err)
+		var encoded []byte
+		if raw, ok := body.(json.RawMessage); ok {
+			encoded = raw
+		} else {
+			var err error
+			encoded, err = json.Marshal(body)
+			if err != nil {
+				return fmt.Errorf("encoding request: %w", err)
+			}
 		}
 		reader = bytes.NewReader(encoded)
 	}

--- a/cmd/reconciliation/internal/clarity/client.go
+++ b/cmd/reconciliation/internal/clarity/client.go
@@ -1,0 +1,89 @@
+package clarity
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+const apiPrefix = "/api/reconciliation"
+
+type Client struct {
+	HTTPClient *http.Client
+	BaseURL    string
+}
+
+func NewClient(cmd *cobra.Command) (*Client, error) {
+	_, profile, profileName, relyingParty, err := fctl.LoadAndAuthenticateCurrentProfile(cmd)
+	if err != nil {
+		return nil, err
+	}
+	clients, err := fctl.NewStackClientsFromFlags(cmd, relyingParty, fctl.NewPTermDialog(), profileName, *profile)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{HTTPClient: clients.HTTPClient, BaseURL: clients.URI}, nil
+}
+
+func (c *Client) Do(cmd *cobra.Command, method, requestPath string, query url.Values, body any, response any) error {
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encoding request: %w", err)
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	endpoint := strings.TrimRight(c.BaseURL, "/") + apiPrefix + requestPath
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(cmd.Context(), method, endpoint, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		var apiError ErrorResponse
+		if json.Unmarshal(responseBody, &apiError) == nil && apiError.ErrorMessage != "" {
+			if apiError.Details != "" {
+				return fmt.Errorf("reconciliation API returned %d (%s): %s: %s", resp.StatusCode, apiError.ErrorCode, apiError.ErrorMessage, apiError.Details)
+			}
+			return fmt.Errorf("reconciliation API returned %d (%s): %s", resp.StatusCode, apiError.ErrorCode, apiError.ErrorMessage)
+		}
+		return fmt.Errorf("reconciliation API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(responseBody)))
+	}
+	if response == nil || len(responseBody) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(responseBody, response); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	return nil
+}
+
+func ResourcePath(resource string) string {
+	return url.PathEscape(resource)
+}

--- a/cmd/reconciliation/internal/clarity/client_test.go
+++ b/cmd/reconciliation/internal/clarity/client_test.go
@@ -1,0 +1,78 @@
+package clarity
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestClientDo(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/reconciliation/rules" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("pageSize"); got != "42" {
+			t.Errorf("pageSize = %q", got)
+		}
+		var query map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if _, ok := query["$match"]; !ok {
+			t.Errorf("body = %#v", query)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"cursor":{"pageSize":42,"hasMore":false,"data":[]}}`))
+	}))
+	defer server.Close()
+
+	client := &Client{HTTPClient: server.Client(), BaseURL: server.URL + "/"}
+	var response CursorResponse[Rule]
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := client.Do(cmd, http.MethodGet, "/rules", url.Values{"pageSize": {"42"}}, map[string]any{
+		"$match": map[string]any{"enabled": true},
+	}, &response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Cursor.PageSize != 42 {
+		t.Fatalf("page size = %d", response.Cursor.PageSize)
+	}
+}
+
+func TestClientDoReturnsStructuredAPIError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errorCode":"VALIDATION","errorMessage":"bad rule","details":"unknown template"}`))
+	}))
+	defer server.Close()
+
+	client := &Client{HTTPClient: server.Client(), BaseURL: server.URL}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := client.Do(cmd, http.MethodPost, "/rules", nil, map[string]any{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "VALIDATION") || !strings.Contains(err.Error(), "unknown template") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestResourcePathEscapesPathSeparators(t *testing.T) {
+	t.Parallel()
+	if got := ResourcePath("rule/one"); got != "rule%2Fone" {
+		t.Fatalf("ResourcePath() = %q", got)
+	}
+}

--- a/cmd/reconciliation/internal/clarity/client_test.go
+++ b/cmd/reconciliation/internal/clarity/client_test.go
@@ -3,6 +3,7 @@ package clarity
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -74,5 +75,29 @@ func TestResourcePathEscapesPathSeparators(t *testing.T) {
 	t.Parallel()
 	if got := ResourcePath("rule/one"); got != "rule%2Fone" {
 		t.Fatalf("ResourcePath() = %q", got)
+	}
+}
+
+func TestClientDoForwardsRawJSONWithoutRounding(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"threshold":9007199254740993}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if string(data) != body {
+			t.Errorf("body = %s, want %s", data, body)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	client := &Client{HTTPClient: server.Client(), BaseURL: server.URL}
+	if err := client.Do(cmd, http.MethodPost, "/rules", nil, json.RawMessage(body), nil); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cmd/reconciliation/internal/clarity/controller.go
+++ b/cmd/reconciliation/internal/clarity/controller.go
@@ -1,0 +1,101 @@
+package clarity
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/spf13/cobra"
+
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type Store map[string]any
+
+type RunFunc func(cmd *cobra.Command, args []string, client *Client) (Store, error)
+type RenderFunc func(cmd *cobra.Command, store Store) error
+
+type Controller struct {
+	store  Store
+	run    RunFunc
+	render RenderFunc
+}
+
+var _ fctl.Controller[Store] = (*Controller)(nil)
+
+func NewController(run RunFunc, render RenderFunc) *Controller {
+	return &Controller{store: Store{}, run: run, render: render}
+}
+
+func (c *Controller) GetStore() Store { return c.store }
+
+func (c *Controller) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	client, err := NewClient(cmd)
+	if err != nil {
+		return nil, err
+	}
+	c.store, err = c.run(cmd, args, client)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *Controller) Render(cmd *cobra.Command, _ []string) error {
+	if c.render != nil {
+		return c.render(cmd, c.store)
+	}
+	return PrintJSON(cmd.OutOrStdout(), c.store)
+}
+
+func PrintJSON(writer io.Writer, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(writer, string(data))
+	return err
+}
+
+func PaginationQuery(cmd *cobra.Command) (url.Values, error) {
+	cursor, err := fctl.GetCursor(cmd)
+	if err != nil {
+		return nil, err
+	}
+	pageSize, err := fctl.GetPageSize(cmd)
+	if err != nil {
+		return nil, err
+	}
+	values := url.Values{}
+	if cursor != "" {
+		values.Set("cursor", cursor)
+		return values, nil
+	}
+	values.Set("pageSize", fmt.Sprintf("%d", pageSize))
+	return values, nil
+}
+
+func QueryBody(cmd *cobra.Command, flag string) (map[string]any, error) {
+	raw, err := cmd.Flags().GetString(flag)
+	if err != nil || raw == "" {
+		return nil, err
+	}
+	var query map[string]any
+	if err := json.Unmarshal([]byte(raw), &query); err != nil {
+		return nil, fmt.Errorf("invalid --%s JSON: %w", flag, err)
+	}
+	return query, nil
+}
+
+func ReadJSONObject(cmd *cobra.Command, path string) (map[string]any, error) {
+	raw, err := fctl.ReadFile(cmd, path)
+	if err != nil {
+		return nil, err
+	}
+	var value map[string]any
+	if err := json.Unmarshal([]byte(raw), &value); err != nil {
+		return nil, fmt.Errorf("invalid JSON in %s: %w", path, err)
+	}
+	return value, nil
+}

--- a/cmd/reconciliation/internal/clarity/controller.go
+++ b/cmd/reconciliation/internal/clarity/controller.go
@@ -77,7 +77,7 @@ func PaginationQuery(cmd *cobra.Command) (url.Values, error) {
 	return values, nil
 }
 
-func QueryBody(cmd *cobra.Command, flag string) (json.RawMessage, error) {
+func QueryBody(cmd *cobra.Command, flag string) (any, error) {
 	raw, err := cmd.Flags().GetString(flag)
 	if err != nil || raw == "" {
 		return nil, err

--- a/cmd/reconciliation/internal/clarity/controller.go
+++ b/cmd/reconciliation/internal/clarity/controller.go
@@ -1,6 +1,7 @@
 package clarity
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -76,32 +77,29 @@ func PaginationQuery(cmd *cobra.Command) (url.Values, error) {
 	return values, nil
 }
 
-func QueryBody(cmd *cobra.Command, flag string) (map[string]any, error) {
+func QueryBody(cmd *cobra.Command, flag string) (json.RawMessage, error) {
 	raw, err := cmd.Flags().GetString(flag)
 	if err != nil || raw == "" {
 		return nil, err
 	}
-	var query map[string]any
-	if err := json.Unmarshal([]byte(raw), &query); err != nil {
-		return nil, fmt.Errorf("invalid --%s JSON: %w", flag, err)
-	}
-	if query == nil {
-		return nil, fmt.Errorf("invalid --%s JSON: expected an object", flag)
-	}
-	return query, nil
+	return parseJSONObject([]byte(raw), fmt.Sprintf("--%s JSON", flag))
 }
 
-func ReadJSONObject(cmd *cobra.Command, path string) (map[string]any, error) {
+func ReadJSONObject(cmd *cobra.Command, path string) (json.RawMessage, error) {
 	raw, err := fctl.ReadFile(cmd, path)
 	if err != nil {
 		return nil, err
 	}
-	var value map[string]any
-	if err := json.Unmarshal([]byte(raw), &value); err != nil {
-		return nil, fmt.Errorf("invalid JSON in %s: %w", path, err)
+	return parseJSONObject([]byte(raw), "JSON in "+path)
+}
+
+func parseJSONObject(raw []byte, source string) (json.RawMessage, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if !json.Valid(trimmed) {
+		return nil, fmt.Errorf("invalid %s", source)
 	}
-	if value == nil {
-		return nil, fmt.Errorf("invalid JSON in %s: expected an object", path)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, fmt.Errorf("invalid %s: expected an object", source)
 	}
-	return value, nil
+	return json.RawMessage(trimmed), nil
 }

--- a/cmd/reconciliation/internal/clarity/controller.go
+++ b/cmd/reconciliation/internal/clarity/controller.go
@@ -85,6 +85,9 @@ func QueryBody(cmd *cobra.Command, flag string) (map[string]any, error) {
 	if err := json.Unmarshal([]byte(raw), &query); err != nil {
 		return nil, fmt.Errorf("invalid --%s JSON: %w", flag, err)
 	}
+	if query == nil {
+		return nil, fmt.Errorf("invalid --%s JSON: expected an object", flag)
+	}
 	return query, nil
 }
 
@@ -96,6 +99,9 @@ func ReadJSONObject(cmd *cobra.Command, path string) (map[string]any, error) {
 	var value map[string]any
 	if err := json.Unmarshal([]byte(raw), &value); err != nil {
 		return nil, fmt.Errorf("invalid JSON in %s: %w", path, err)
+	}
+	if value == nil {
+		return nil, fmt.Errorf("invalid JSON in %s: expected an object", path)
 	}
 	return value, nil
 }

--- a/cmd/reconciliation/internal/clarity/controller_test.go
+++ b/cmd/reconciliation/internal/clarity/controller_test.go
@@ -1,6 +1,7 @@
 package clarity
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +22,43 @@ func TestQueryBodyRejectsNull(t *testing.T) {
 	_, err := QueryBody(cmd, "query")
 	if err == nil || !strings.Contains(err.Error(), "expected an object") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestQueryBodyWithoutValueReturnsNilInterface(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("query", "", "")
+	body, err := QueryBody(cmd, "query")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != nil {
+		t.Fatalf("body = %#v, want nil", body)
+	}
+}
+
+func TestQueryBodyPreservesLargeNumbers(t *testing.T) {
+	t.Parallel()
+
+	const query = `{"$match":{"threshold":9007199254740993}}`
+	cmd := &cobra.Command{}
+	cmd.Flags().String("query", "", "")
+	if err := cmd.Flags().Set("query", query); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := QueryBody(cmd, "query")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, ok := body.(json.RawMessage)
+	if !ok {
+		t.Fatalf("body type = %T, want json.RawMessage", body)
+	}
+	if string(raw) != query {
+		t.Fatalf("body = %s, want %s", raw, query)
 	}
 }
 

--- a/cmd/reconciliation/internal/clarity/controller_test.go
+++ b/cmd/reconciliation/internal/clarity/controller_test.go
@@ -37,3 +37,21 @@ func TestReadJSONObjectRejectsNull(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestReadJSONObjectPreservesLargeNumbers(t *testing.T) {
+	t.Parallel()
+
+	const request = `{"threshold":9007199254740993}`
+	path := filepath.Join(t.TempDir(), "request.json")
+	if err := os.WriteFile(path, []byte(request), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ReadJSONObject(&cobra.Command{}, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != request {
+		t.Fatalf("body = %s, want %s", body, request)
+	}
+}

--- a/cmd/reconciliation/internal/clarity/controller_test.go
+++ b/cmd/reconciliation/internal/clarity/controller_test.go
@@ -1,0 +1,39 @@
+package clarity
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestQueryBodyRejectsNull(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("query", "", "")
+	if err := cmd.Flags().Set("query", "null"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := QueryBody(cmd, "query")
+	if err == nil || !strings.Contains(err.Error(), "expected an object") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestReadJSONObjectRejectsNull(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "request.json")
+	if err := os.WriteFile(path, []byte("null"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ReadJSONObject(&cobra.Command{}, path)
+	if err == nil || !strings.Contains(err.Error(), "expected an object") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/cmd/reconciliation/internal/clarity/models.go
+++ b/cmd/reconciliation/internal/clarity/models.go
@@ -1,0 +1,103 @@
+package clarity
+
+import "encoding/json"
+
+type ErrorResponse struct {
+	ErrorCode    string `json:"errorCode"`
+	ErrorMessage string `json:"errorMessage"`
+	Details      string `json:"details"`
+}
+
+type Cursor[T any] struct {
+	PageSize int64   `json:"pageSize"`
+	HasMore  bool    `json:"hasMore"`
+	Previous *string `json:"previous,omitempty"`
+	Next     *string `json:"next,omitempty"`
+	Data     []T     `json:"data"`
+}
+
+type CursorResponse[T any] struct {
+	Cursor Cursor[T] `json:"cursor"`
+}
+
+type PageCursor struct {
+	PageSize int64   `json:"pageSize"`
+	HasMore  bool    `json:"hasMore"`
+	Previous *string `json:"previous,omitempty"`
+	Next     *string `json:"next,omitempty"`
+}
+
+func Page[T any](cursor Cursor[T]) PageCursor {
+	return PageCursor{
+		PageSize: cursor.PageSize,
+		HasMore:  cursor.HasMore,
+		Previous: cursor.Previous,
+		Next:     cursor.Next,
+	}
+}
+
+type DataResponse[T any] struct {
+	Data T `json:"data"`
+}
+
+type Rule struct {
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	TemplateKind   string            `json:"templateKind"`
+	TemplateSpec   json.RawMessage   `json:"templateSpec"`
+	ExplanationCEL string            `json:"explanationCEL,omitempty"`
+	Enabled        bool              `json:"enabled"`
+	Severity       string            `json:"severity"`
+	Cadence        string            `json:"cadence"`
+	Schedule       json.RawMessage   `json:"schedule,omitempty"`
+	Notifications  []string          `json:"notifications,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	CreatedAt      string            `json:"createdAt"`
+	UpdatedAt      string            `json:"updatedAt"`
+}
+
+type Evaluation struct {
+	ID           string            `json:"id"`
+	RuleID       string            `json:"ruleID"`
+	StartedAt    string            `json:"startedAt"`
+	EndedAt      string            `json:"endedAt"`
+	PITPerSource map[string]string `json:"pitPerSource,omitempty"`
+	Result       string            `json:"result"`
+	Evidence     json.RawMessage   `json:"evidence,omitempty"`
+	Error        string            `json:"error,omitempty"`
+	CostUnits    int64             `json:"costUnits,omitempty"`
+	CreatedAt    string            `json:"createdAt"`
+}
+
+type Alert struct {
+	ID               string            `json:"id"`
+	RuleID           string            `json:"ruleID"`
+	Fingerprint      string            `json:"fingerprint"`
+	PeriodID         string            `json:"periodID"`
+	Status           string            `json:"status"`
+	Severity         string            `json:"severity"`
+	FirstSeenAt      string            `json:"firstSeenAt"`
+	LastSeenAt       string            `json:"lastSeenAt"`
+	OccurrenceCount  int64             `json:"occurrenceCount"`
+	LastEvaluationID string            `json:"lastEvaluationID"`
+	Evidence         json.RawMessage   `json:"evidence,omitempty"`
+	Ack              json.RawMessage   `json:"ack,omitempty"`
+	Resolution       json.RawMessage   `json:"resolution,omitempty"`
+	Snooze           json.RawMessage   `json:"snooze,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	CreatedAt        string            `json:"createdAt"`
+	UpdatedAt        string            `json:"updatedAt"`
+}
+
+type AlertEvent struct {
+	ID           string          `json:"id"`
+	AlertID      string          `json:"alertID"`
+	EvaluationID *string         `json:"evaluationID,omitempty"`
+	Type         string          `json:"type"`
+	Previous     *string         `json:"prevStatus,omitempty"`
+	NewStatus    string          `json:"newStatus"`
+	Payload      json.RawMessage `json:"payload,omitempty"`
+	At           string          `json:"at"`
+	IsReopen     bool            `json:"isReopen"`
+	Notify       bool            `json:"notify"`
+}

--- a/cmd/reconciliation/root.go
+++ b/cmd/reconciliation/root.go
@@ -3,7 +3,10 @@ package reconciliation
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/formancehq/fctl/v3/cmd/reconciliation/alerts"
+	"github.com/formancehq/fctl/v3/cmd/reconciliation/evaluations"
 	"github.com/formancehq/fctl/v3/cmd/reconciliation/policies"
+	"github.com/formancehq/fctl/v3/cmd/reconciliation/rules"
 	fctl "github.com/formancehq/fctl/v3/pkg"
 )
 
@@ -12,6 +15,9 @@ func NewCommand() *cobra.Command {
 		fctl.WithShortDescription("Manage reconciliation"),
 		fctl.WithChildCommands(
 			policies.NewPoliciesCommand(),
+			rules.NewCommand(),
+			evaluations.NewCommand(),
+			alerts.NewCommand(),
 			NewListCommand(),
 			NewShowCommand(),
 		),

--- a/cmd/reconciliation/root_test.go
+++ b/cmd/reconciliation/root_test.go
@@ -1,0 +1,37 @@
+package reconciliation
+
+import "testing"
+
+func TestLedgerClarityCommandSurface(t *testing.T) {
+	t.Parallel()
+
+	root := NewCommand()
+	commands := [][]string{
+		{"rules", "list"},
+		{"rules", "get"},
+		{"rules", "create"},
+		{"rules", "update"},
+		{"rules", "delete"},
+		{"rules", "evaluate"},
+		{"evaluations", "list"},
+		{"evaluations", "get"},
+		{"alerts", "list"},
+		{"alerts", "get"},
+		{"alerts", "events"},
+		{"alerts", "ack"},
+		{"alerts", "resolve"},
+		{"alerts", "accept"},
+		{"alerts", "snooze"},
+		{"alerts", "unsnooze"},
+	}
+	for _, path := range commands {
+		command, remaining, err := root.Find(path)
+		if err != nil {
+			t.Errorf("find %v: %v", path, err)
+			continue
+		}
+		if len(remaining) != 0 || command.Name() != path[len(path)-1] {
+			t.Errorf("find %v returned %q with remaining %v", path, command.Name(), remaining)
+		}
+	}
+}

--- a/cmd/reconciliation/root_test.go
+++ b/cmd/reconciliation/root_test.go
@@ -35,3 +35,15 @@ func TestLedgerClarityCommandSurface(t *testing.T) {
 		}
 	}
 }
+
+func TestEvaluateCommandRequiresConfirmation(t *testing.T) {
+	t.Parallel()
+
+	command, _, err := NewCommand().Find([]string{"rules", "evaluate"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command.Flags().Lookup("confirm") == nil {
+		t.Fatal("evaluate command does not expose --confirm")
+	}
+}

--- a/cmd/reconciliation/rules/root.go
+++ b/cmd/reconciliation/rules/root.go
@@ -1,0 +1,208 @@
+package rules
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+
+	"github.com/formancehq/fctl/v3/cmd/reconciliation/internal/clarity"
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+const queryFlag = "query"
+
+func NewCommand() *cobra.Command {
+	return fctl.NewCommand("rules",
+		fctl.WithAliases("rule"),
+		fctl.WithShortDescription("Manage Ledger Clarity rules"),
+		fctl.WithChildCommands(
+			newListCommand(),
+			newGetCommand(),
+			newCreateCommand(),
+			newUpdateCommand(),
+			newDeleteCommand(),
+			newEvaluateCommand(),
+		),
+	)
+}
+
+func newListCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, _ []string, client *clarity.Client) (clarity.Store, error) {
+		query, err := clarity.PaginationQuery(cmd)
+		if err != nil {
+			return nil, err
+		}
+		var body any
+		if query.Get("cursor") == "" {
+			body, err = clarity.QueryBody(cmd, queryFlag)
+			if err != nil {
+				return nil, err
+			}
+		}
+		var response clarity.CursorResponse[clarity.Rule]
+		if err := client.Do(cmd, http.MethodGet, "/rules", query, body, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"rules": response.Cursor.Data, "cursor": clarity.Page(response.Cursor)}, nil
+	}, renderRules)
+	return fctl.NewCommand("list",
+		fctl.WithAliases("ls", "l"),
+		fctl.WithShortDescription("List rules"),
+		fctl.WithArgs(cobra.NoArgs),
+		fctl.WithCursorFlag(),
+		fctl.WithPageSizeFlag(),
+		fctl.WithStringFlag(queryFlag, "", "Query-builder expression as JSON"),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func newGetCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		var response clarity.DataResponse[clarity.Rule]
+		if err := client.Do(cmd, http.MethodGet, "/rules/"+clarity.ResourcePath(args[0]), nil, nil, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"rule": response.Data}, nil
+	}, nil)
+	return fctl.NewCommand("get <ruleID>",
+		fctl.WithAliases("show", "sh", "s"),
+		fctl.WithShortDescription("Get a rule"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func newCreateCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		if !fctl.CheckStackApprobation(cmd, "You are about to create a reconciliation rule") {
+			return nil, fctl.ErrMissingApproval
+		}
+		body, err := clarity.ReadJSONObject(cmd, args[0])
+		if err != nil {
+			return nil, err
+		}
+		var response clarity.DataResponse[clarity.Rule]
+		if err := client.Do(cmd, http.MethodPost, "/rules", nil, body, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"rule": response.Data}, nil
+	}, func(cmd *cobra.Command, store clarity.Store) error {
+		rule := store["rule"].(clarity.Rule)
+		pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Rule created with ID: %s", rule.ID)
+		return nil
+	})
+	return fctl.NewCommand("create <file>|-",
+		fctl.WithAliases("cr", "c"),
+		fctl.WithShortDescription("Create a rule from a JSON file"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithConfirmFlag(),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func newUpdateCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		if !fctl.CheckStackApprobation(cmd, "You are about to update rule '%s'", args[0]) {
+			return nil, fctl.ErrMissingApproval
+		}
+		body, err := clarity.ReadJSONObject(cmd, args[1])
+		if err != nil {
+			return nil, err
+		}
+		var response clarity.DataResponse[clarity.Rule]
+		if err := client.Do(cmd, http.MethodPatch, "/rules/"+clarity.ResourcePath(args[0]), nil, body, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"rule": response.Data}, nil
+	}, nil)
+	return fctl.NewCommand("update <ruleID> <file>|-",
+		fctl.WithAliases("patch"),
+		fctl.WithShortDescription("Partially update a rule from a JSON file"),
+		fctl.WithArgs(cobra.ExactArgs(2)),
+		fctl.WithConfirmFlag(),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func newDeleteCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		if !fctl.CheckStackApprobation(cmd, "You are about to delete rule '%s' and its evaluations and alerts", args[0]) {
+			return nil, fctl.ErrMissingApproval
+		}
+		if err := client.Do(cmd, http.MethodDelete, "/rules/"+clarity.ResourcePath(args[0]), nil, nil, nil); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"ruleID": args[0], "success": true}, nil
+	}, func(cmd *cobra.Command, store clarity.Store) error {
+		pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Rule %s deleted.", store["ruleID"])
+		return nil
+	})
+	return fctl.NewCommand("delete <ruleID>",
+		fctl.WithAliases("d"),
+		fctl.WithShortDescription("Delete a rule"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithConfirmFlag(),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func newEvaluateCommand() *cobra.Command {
+	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		body := map[string]any{}
+		if at := fctl.GetString(cmd, "at"); at != "" {
+			body["at"] = at
+		}
+		if margin := fctl.GetString(cmd, "safety-margin"); margin != "" {
+			body["safetyMargin"] = margin
+		}
+		sourcePITValues, err := cmd.Flags().GetStringArray("source-pit")
+		if err != nil {
+			return nil, err
+		}
+		if len(sourcePITValues) > 0 {
+			sourcePITs := map[string]string{}
+			for _, item := range sourcePITValues {
+				parts := strings.SplitN(item, "=", 2)
+				if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+					return nil, fmt.Errorf("invalid --source-pit %q: expected key=RFC3339", item)
+				}
+				sourcePITs[parts[0]] = parts[1]
+			}
+			body["sourcePITs"] = sourcePITs
+		}
+		var response clarity.DataResponse[clarity.Evaluation]
+		path := "/rules/" + clarity.ResourcePath(args[0]) + "/evaluate"
+		if err := client.Do(cmd, http.MethodPost, path, nil, body, &response); err != nil {
+			return nil, err
+		}
+		return clarity.Store{"evaluation": response.Data}, nil
+	}, nil)
+	return fctl.NewCommand("evaluate <ruleID>",
+		fctl.WithAliases("run"),
+		fctl.WithShortDescription("Evaluate a rule now"),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithStringFlag("at", "", "Canonical point in time (RFC3339; defaults to now)"),
+		fctl.WithStringFlag("safety-margin", "", "Safety margin as a Go duration (for example 30s)"),
+		fctl.WithStringArrayFlag("source-pit", nil, "Per-source PIT as key=RFC3339 (repeatable)"),
+		fctl.WithValidArgsFunction(cobra.NoFileCompletions),
+		fctl.WithController[clarity.Store](controller),
+	)
+}
+
+func renderRules(cmd *cobra.Command, store clarity.Store) error {
+	rules := store["rules"].([]clarity.Rule)
+	rows := pterm.TableData{{"ID", "Name", "Template", "Enabled", "Severity", "Cadence", "UpdatedAt"}}
+	for _, rule := range rules {
+		rows = append(rows, []string{rule.ID, rule.Name, rule.TemplateKind, fmt.Sprint(rule.Enabled), rule.Severity, rule.Cadence, rule.UpdatedAt})
+	}
+	if err := pterm.DefaultTable.WithHasHeader().WithWriter(cmd.OutOrStdout()).WithData(rows).Render(); err != nil {
+		return err
+	}
+	cursor := store["cursor"].(clarity.PageCursor)
+	return fctl.RenderCursor(cmd.OutOrStdout(), fctl.Cursor{HasMore: cursor.HasMore, PageSize: cursor.PageSize, Next: cursor.Next, Previous: cursor.Previous})
+}

--- a/cmd/reconciliation/rules/root.go
+++ b/cmd/reconciliation/rules/root.go
@@ -153,6 +153,9 @@ func newDeleteCommand() *cobra.Command {
 
 func newEvaluateCommand() *cobra.Command {
 	controller := clarity.NewController(func(cmd *cobra.Command, args []string, client *clarity.Client) (clarity.Store, error) {
+		if !fctl.CheckStackApprobation(cmd, "You are about to evaluate rule '%s'", args[0]) {
+			return nil, fctl.ErrMissingApproval
+		}
 		body := map[string]any{}
 		if at := fctl.GetString(cmd, "at"); at != "" {
 			body["at"] = at
@@ -186,6 +189,7 @@ func newEvaluateCommand() *cobra.Command {
 		fctl.WithAliases("run"),
 		fctl.WithShortDescription("Evaluate a rule now"),
 		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithConfirmFlag(),
 		fctl.WithStringFlag("at", "", "Canonical point in time (RFC3339; defaults to now)"),
 		fctl.WithStringFlag("safety-margin", "", "Safety margin as a Go duration (for example 30s)"),
 		fctl.WithStringArrayFlag("source-pit", nil, "Per-source PIT as key=RFC3339 (repeatable)"),


### PR DESCRIPTION
## What changed

- add `reconciliation rules` commands for list, get, create, update, delete, and evaluate
- add `reconciliation evaluations` commands for list and get
- add `reconciliation alerts` commands for list, get, event history, acknowledge, resolve, accept, snooze, and unsnooze
- add an authenticated HTTP client for the Ledger Clarity endpoints that are not yet available in the published Go SDK
- support query-builder filters, cursor pagination, JSON output, structured API errors, and confirmation prompts for mutations

## Why

Reconciliation now exposes the Ledger Clarity V1 API surface for rules, evaluations, and alerts, while `fctl` only supported the legacy policies and reconciliations endpoints.

## Impact

Operators can manage the complete Ledger Clarity lifecycle directly from `fctl` without falling back to raw HTTP requests.

## Validation

- `go test ./...`
- `go test -race ./cmd/reconciliation/...`
- `go vet ./...`
- `go build ./...`
- `nix develop --impure --command just lint`
- `git diff --check`