### PR TITLE
feat(stack): sort available versions newest first

### DIFF
--- a/cmd/stack/create.go
+++ b/cmd/stack/create.go
@@ -1,12 +1,15 @@
 package stack
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 
 	"github.com/formancehq/fctl/internal/membershipclient/v3/models/components"
 	"github.com/formancehq/fctl/internal/membershipclient/v3/models/operations"
@@ -155,6 +158,7 @@ func (c *CreateController) Run(cmd *cobra.Command, args []string) (fctl.Renderab
 		for _, version := range availableVersionsResponse.GetRegionVersionsResponse.GetData() {
 			options = append(options, version.GetName())
 		}
+		sortVersionsDescending(options)
 
 		selectedOption := ""
 		if len(options) > 0 {
@@ -248,4 +252,13 @@ func (c *CreateController) Run(cmd *cobra.Command, args []string) (fctl.Renderab
 
 func (c *CreateController) Render(cmd *cobra.Command, _ []string) error {
 	return internal.PrintStackInformation(cmd.OutOrStdout(), c.store.Stack, c.store.Versions)
+}
+
+func sortVersionsDescending(versions []string) {
+	slices.SortFunc(versions, func(a, b string) int {
+		if order := semver.Compare(b, a); order != 0 {
+			return order
+		}
+		return cmp.Compare(b, a)
+	})
 }

--- a/cmd/stack/create_test.go
+++ b/cmd/stack/create_test.go
@@ -12,6 +12,9 @@ func TestSortVersionsDescending(t *testing.T) {
 		"v3.0.0-rc.1",
 		"v2.10.0",
 		"v3.0.0",
+		"v1.0.0+build.1",
+		"v1.0.0+build.2",
+		"preview",
 		"development",
 	}
 
@@ -22,6 +25,9 @@ func TestSortVersionsDescending(t *testing.T) {
 		"v3.0.0-rc.1",
 		"v2.10.0",
 		"v2.9.0",
+		"v1.0.0+build.2",
+		"v1.0.0+build.1",
+		"preview",
 		"development",
 	}, versions)
 }

--- a/cmd/stack/create_test.go
+++ b/cmd/stack/create_test.go
@@ -1,0 +1,27 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortVersionsDescending(t *testing.T) {
+	versions := []string{
+		"v2.9.0",
+		"v3.0.0-rc.1",
+		"v2.10.0",
+		"v3.0.0",
+		"development",
+	}
+
+	sortVersionsDescending(versions)
+
+	assert.Equal(t, []string{
+		"v3.0.0",
+		"v3.0.0-rc.1",
+		"v2.10.0",
+		"v2.9.0",
+		"development",
+	}, versions)
+}


### PR DESCRIPTION
## Summary

- sort stack versions by semantic version in descending order during interactive stack creation
- keep non-semantic version labels after valid semantic versions with deterministic ordering
- cover numeric and pre-release ordering with a focused unit test

## Validation

- `nix develop --impure --command just lint`
- `go test ./...`
- `git diff --check`

## Risk

Low. The change only affects the ordering of options shown by the interactive stack creation prompt.