### PR TITLE
feat(connectivity): suspend connector instances

### DIFF
--- a/cmd/connectivity/connectorinstances/root.go
+++ b/cmd/connectivity/connectorinstances/root.go
@@ -17,6 +17,8 @@ func NewCommand(factory connectivityinternal.ClientFactory, read ReadFileFunc, p
 			NewShowCommand(factory),
 			NewInstallCommand(factory, read, paths),
 			NewConfigureCommand(factory, read, paths),
+			NewSuspendCommand(factory),
+			NewUnsuspendCommand(factory),
 			NewUninstallCommand(factory),
 		),
 	)

--- a/cmd/connectivity/connectorinstances/show.go
+++ b/cmd/connectivity/connectorinstances/show.go
@@ -88,6 +88,8 @@ func (c *ShowController) Render(cmd *cobra.Command, _ []string) error {
 		{pterm.LightCyan("Connectivity Reference"), stringValue(instance.Spec.ConnectivityRef)},
 		{pterm.LightCyan("Ledger"), instance.Spec.Ledger},
 		{pterm.LightCyan("Poll Interval"), stringValue(instance.Spec.PollInterval)},
+		{pterm.LightCyan("Suspend"), boolValue(instance.Spec.Suspend)},
+		{pterm.LightCyan("Replicas"), int32Value(instance.Spec.Replicas)},
 	}); err != nil {
 		return err
 	}
@@ -99,6 +101,7 @@ func (c *ShowController) Render(cmd *cobra.Command, _ []string) error {
 		{pterm.LightCyan("Connector Address"), instanceStatusValue(instance.Status, func(status *connectivityclient.ConnectorInstanceStatus) *string { return status.ConnectorAddress })},
 		{pterm.LightCyan("Phase"), instanceStatusValue(instance.Status, func(status *connectivityclient.ConnectorInstanceStatus) *string { return status.Phase })},
 		{pterm.LightCyan("State"), instanceStatusValue(instance.Status, func(status *connectivityclient.ConnectorInstanceStatus) *string { return status.State })},
+		{pterm.LightCyan("Suspended by"), instanceSuspensionSources(instance.Status)},
 	}); err != nil {
 		return err
 	}
@@ -181,6 +184,37 @@ func mapValue(value map[string]string) string {
 	entries := make([]string, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, key+"="+value[key])
+	}
+	return strings.Join(entries, ", ")
+}
+
+func boolValue(value *bool) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.FormatBool(*value)
+}
+
+func int32Value(value *int32) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.FormatInt(int64(*value), 10)
+}
+
+func instanceSuspensionSources(status *connectivityclient.ConnectorInstanceStatus) string {
+	if status == nil {
+		return ""
+	}
+	// Connectivity orders instance fields first and Policies by priority/name.
+	// Preserve that API order because Policy priority is not part of this model.
+	entries := make([]string, 0, len(status.SuspendedBy))
+	for _, source := range status.SuspendedBy {
+		entry := strings.Join(nonEmptyStrings(source.Kind, source.Name), "/")
+		if source.Field != "" {
+			entry += " (" + source.Field + ")"
+		}
+		entries = append(entries, entry)
 	}
 	return strings.Join(entries, ", ")
 }

--- a/cmd/connectivity/connectorinstances/show_test.go
+++ b/cmd/connectivity/connectorinstances/show_test.go
@@ -120,6 +120,27 @@ func TestShowConnectorInstanceHandlesMissingStatusAndConfig(t *testing.T) {
 	require.Contains(t, output, "No configuration entries.")
 }
 
+func TestShowConnectorInstanceRendersDesiredSuspensionReplicasAndOrderedProvenance(t *testing.T) {
+	instance := instanceFixture("stripe-eu")
+	instance.Spec.Suspend = fctl.Ptr(true)
+	instance.Spec.Replicas = fctl.Ptr(int32(0))
+	instance.Status.SuspendedBy = []connectivityclient.SuspensionSource{
+		{Kind: "ConnectorInstance", Name: "stripe-eu", Field: "spec.suspend"},
+		{Kind: "ConnectorInstance", Name: "stripe-eu", Field: "spec.replicas"},
+		{Kind: "Policy", Name: "maintenance", Field: "spec.mutate.suspend"},
+	}
+
+	output, err := executeCommand(NewShowCommand(factoryWithInstance(instance)), "stripe-eu")
+
+	require.NoError(t, err)
+	require.Contains(t, output, "Suspend")
+	require.Contains(t, output, "true")
+	require.Contains(t, output, "Replicas")
+	require.Contains(t, output, "0")
+	require.Contains(t, output, "Suspended by")
+	require.Contains(t, output, "ConnectorInstance/stripe-eu (spec.suspend), ConnectorInstance/stripe-eu (spec.replicas), Policy/maintenance (spec.mutate.suspend)")
+}
+
 func TestShowConnectorInstanceReturnsFactoryAPIAndEmptyResponseErrors(t *testing.T) {
 	tests := map[string]struct {
 		factory func(*cobra.Command) (connectivityclient.Client, error)

--- a/cmd/connectivity/connectorinstances/suspend.go
+++ b/cmd/connectivity/connectorinstances/suspend.go
@@ -1,0 +1,94 @@
+package connectorinstances
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	connectivityinternal "github.com/formancehq/fctl/v3/cmd/connectivity/internal"
+	connectivityclient "github.com/formancehq/fctl/v3/internal/connectivityclient"
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type SuspensionStore struct {
+	Name    string `json:"name"`
+	Suspend bool   `json:"suspend"`
+}
+
+type SuspensionController struct {
+	factory connectivityinternal.ClientFactory
+	approve approvalFunc
+	store   *SuspensionStore
+	suspend bool
+}
+
+var _ fctl.Controller[*SuspensionStore] = (*SuspensionController)(nil)
+
+func NewSuspensionController(factory connectivityinternal.ClientFactory, suspend bool) *SuspensionController {
+	return &SuspensionController{
+		factory: factory,
+		approve: fctl.CheckStackApprobation,
+		store:   &SuspensionStore{},
+		suspend: suspend,
+	}
+}
+
+func NewSuspendCommand(factory connectivityinternal.ClientFactory) *cobra.Command {
+	return newSuspensionCommand(factory, "suspend", "Suspend a Connectivity connector instance", true)
+}
+
+func NewUnsuspendCommand(factory connectivityinternal.ClientFactory) *cobra.Command {
+	return newSuspensionCommand(factory, "unsuspend", "Resume a Connectivity connector instance", false)
+}
+
+func newSuspensionCommand(factory connectivityinternal.ClientFactory, name, description string, suspend bool) *cobra.Command {
+	controller := NewSuspensionController(factory, suspend)
+	return fctl.NewCommand(
+		name+" <connectorinstance>",
+		fctl.WithShortDescription(description),
+		fctl.WithArgs(cobra.ExactArgs(1)),
+		fctl.WithValidArgsFunction(CompleteConnectorInstanceNames(factory)),
+		fctl.WithConfirmFlag(),
+		fctl.WithController[*SuspensionStore](controller),
+	)
+}
+
+func (c *SuspensionController) GetStore() *SuspensionStore {
+	return c.store
+}
+
+func (c *SuspensionController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	if c.factory == nil {
+		return nil, fmt.Errorf("connectivity client factory is required")
+	}
+	client, err := c.factory(cmd)
+	if err != nil {
+		return nil, err
+	}
+	name := args[0]
+	action := "suspend"
+	if !c.suspend {
+		action = "resume"
+	}
+	if !c.approve(cmd, "You are about to %s Connectivity connector instance %q", action, name) {
+		return nil, fctl.ErrMissingApproval
+	}
+	_, err = client.PatchConnectorInstance(cmd.Context(), name, connectivityclient.ConnectorInstancePatch{
+		"spec": map[string]any{"suspend": c.suspend},
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.store.Name = name
+	c.store.Suspend = c.suspend
+	return c, nil
+}
+
+func (c *SuspensionController) Render(cmd *cobra.Command, _ []string) error {
+	request := "suspension"
+	if !c.store.Suspend {
+		request = "resumption"
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "Connector instance %q %s requested.\n", c.store.Name, request)
+	return err
+}

--- a/cmd/connectivity/connectorinstances/suspend_test.go
+++ b/cmd/connectivity/connectorinstances/suspend_test.go
@@ -1,0 +1,136 @@
+package connectorinstances
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	connectivityinternal "github.com/formancehq/fctl/v3/cmd/connectivity/internal"
+	connectivityclient "github.com/formancehq/fctl/v3/internal/connectivityclient"
+	fctl "github.com/formancehq/fctl/v3/pkg"
+)
+
+type suspensionClientMock struct {
+	connectivityclient.Client
+	listInstances func(context.Context, connectivityclient.ListOptions) (*connectivityclient.ConnectorInstanceList, error)
+	patch         func(context.Context, string, connectivityclient.ConnectorInstancePatch) (*connectivityclient.ConnectorInstance, error)
+}
+
+func (m suspensionClientMock) ListConnectorInstances(ctx context.Context, options connectivityclient.ListOptions) (*connectivityclient.ConnectorInstanceList, error) {
+	return m.listInstances(ctx, options)
+}
+
+func (m suspensionClientMock) PatchConnectorInstance(ctx context.Context, name string, patch connectivityclient.ConnectorInstancePatch) (*connectivityclient.ConnectorInstance, error) {
+	return m.patch(ctx, name, patch)
+}
+
+func TestSuspensionCommandsPatchOnlyDesiredBooleanAndTreatAlreadyConvergedResponseAsSuccess(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    func(connectivityinternal.ClientFactory) *cobra.Command
+		suspend    bool
+		wantOutput string
+	}{
+		{name: "suspend", command: NewSuspendCommand, suspend: true, wantOutput: `Connector instance "stripe-eu" suspension requested.`},
+		{name: "unsuspend", command: NewUnsuspendCommand, suspend: false, wantOutput: `Connector instance "stripe-eu" resumption requested.`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			client := suspensionClientMock{patch: func(_ context.Context, name string, patch connectivityclient.ConnectorInstancePatch) (*connectivityclient.ConnectorInstance, error) {
+				calls++
+				require.Equal(t, "stripe-eu", name)
+				require.Equal(t, connectivityclient.ConnectorInstancePatch{"spec": map[string]any{"suspend": test.suspend}}, patch)
+				instance := instanceFixture(name)
+				instance.Spec.Suspend = fctl.Ptr(test.suspend)
+				return &instance, nil
+			}}
+
+			output, err := executeCommand(test.command(factoryReturning(client)), "stripe-eu", "--confirm")
+
+			require.NoError(t, err)
+			require.Equal(t, 1, calls)
+			require.Equal(t, test.wantOutput, strings.TrimSpace(output))
+		})
+	}
+}
+
+func TestSuspensionCommandConfirmationRejectionMakesNoPatch(t *testing.T) {
+	patchCalls := 0
+	client := suspensionClientMock{patch: func(context.Context, string, connectivityclient.ConnectorInstancePatch) (*connectivityclient.ConnectorInstance, error) {
+		patchCalls++
+		return nil, errors.New("PatchConnectorInstance must not be called")
+	}}
+	controller := NewSuspensionController(factoryReturning(client), true)
+	controller.approve = func(*cobra.Command, string, ...any) bool { return false }
+
+	_, err := controller.Run(&cobra.Command{}, []string{"stripe-eu"})
+
+	require.ErrorIs(t, err, fctl.ErrMissingApproval)
+	require.Zero(t, patchCalls)
+}
+
+func TestSuspensionCommandsPreserveAPIError(t *testing.T) {
+	apiError := &connectivityclient.APIError{StatusCode: 409, Code: "CONFLICT", Message: "stale"}
+	client := suspensionClientMock{patch: func(context.Context, string, connectivityclient.ConnectorInstancePatch) (*connectivityclient.ConnectorInstance, error) {
+		return nil, apiError
+	}}
+
+	for _, command := range []func(connectivityinternal.ClientFactory) *cobra.Command{NewSuspendCommand, NewUnsuspendCommand} {
+		_, err := executeCommand(command(factoryReturning(client)), "stripe-eu", "--confirm")
+		require.ErrorIs(t, err, apiError)
+	}
+}
+
+func TestSuspensionCommandsRejectInvalidArgumentsBeforeUsingClient(t *testing.T) {
+	usedFactory := false
+	factory := func(*cobra.Command) (connectivityclient.Client, error) {
+		usedFactory = true
+		return nil, errors.New("factory must not be used")
+	}
+
+	for _, command := range []func(connectivityinternal.ClientFactory) *cobra.Command{NewSuspendCommand, NewUnsuspendCommand} {
+		_, err := executeCommand(command(factory), "stripe-eu", "extra", "--confirm")
+		require.Error(t, err)
+	}
+	require.False(t, usedFactory)
+}
+
+func TestSuspensionCommandsRegisterConfirmationCompletionAndRootChildren(t *testing.T) {
+	instance := instanceFixture("stripe-eu")
+	client := suspensionClientMock{listInstances: func(ctx context.Context, options connectivityclient.ListOptions) (*connectivityclient.ConnectorInstanceList, error) {
+		require.True(t, connectivityinternal.IsNonInteractive(ctx))
+		require.Equal(t, connectivityclient.ListOptions{PageSize: 100}, options)
+		return &connectivityclient.ConnectorInstanceList{Items: []connectivityclient.ConnectorInstance{instance}}, nil
+	}}
+
+	for _, test := range []struct {
+		name    string
+		command func(connectivityinternal.ClientFactory) *cobra.Command
+	}{
+		{name: "suspend", command: NewSuspendCommand},
+		{name: "unsuspend", command: NewUnsuspendCommand},
+	} {
+		command := test.command(factoryReturning(client))
+		require.Equal(t, test.name+" <connectorinstance>", command.Use)
+		require.NotNil(t, command.Flags().Lookup("confirm"))
+		require.Error(t, command.Args(command, nil))
+		require.NoError(t, command.Args(command, []string{"stripe-eu"}))
+		require.Error(t, command.Args(command, []string{"stripe-eu", "extra"}))
+		candidates, directive := command.ValidArgsFunction(command, nil, "stripe")
+		require.Equal(t, []string{"stripe-eu\tstripe · main"}, candidates)
+		require.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	}
+
+	root := NewCommand(nil, mockReadFile(nil), mockPathCompleter(nil))
+	for _, name := range []string{"suspend", "unsuspend"} {
+		child, _, err := root.Find([]string{name})
+		require.NoError(t, err)
+		require.Equal(t, name, child.Name())
+	}
+}

--- a/docs/connectivity.md
+++ b/docs/connectivity.md
@@ -14,6 +14,8 @@ fctl connectivity connectorinstances list [--connector NAME] [--filter KEY=VALUE
 fctl connectivity connectorinstances show <instance>
 fctl connectivity connectorinstances install <connector> --ledger <ledger>
 fctl connectivity connectorinstances configure <instance>
+fctl connectivity connectorinstances suspend <instance> --confirm
+fctl connectivity connectorinstances unsuspend <instance> --confirm
 fctl connectivity connectorinstances uninstall <instance>
 ```
 
@@ -21,6 +23,24 @@ Short aliases are available for the common list and catalogue commands:
 `connectors ls`, `connectors l`, `connectors facets` (`facet`, `f`), and
 `connectorinstances ls` (`l`). `install` also accepts `create` and `in`;
 `configure` accepts `config`, `update`, and `c`.
+
+## Suspension and resumption
+
+`connectorinstances suspend` and `connectorinstances unsuspend` request the
+desired ingestion state through the Connectivity API. Both commands require
+confirmation, either interactively or with `--confirm`:
+
+```bash
+fctl connectivity connectorinstances suspend stripe-prod --confirm
+fctl connectivity connectorinstances unsuspend stripe-prod --confirm
+```
+
+A successful command means the request was accepted; reconciliation may still
+be in progress. Use `connectorinstances show <instance>` to compare the desired
+`Suspend` and `Replicas` values with the observed phase, state, and
+`Suspended by` provenance. Suspension can also remain effective because the
+desired replica count is zero or a matching Policy contributes a suspension
+source.
 
 ## Filtering and pagination
 

--- a/internal/connectivityclient/client_test.go
+++ b/internal/connectivityclient/client_test.go
@@ -361,6 +361,70 @@ func TestPatchConnectorInstanceSendsAPIShapedConfig(t *testing.T) {
 	}`, string(seenBody))
 }
 
+func TestPatchConnectorInstanceSendsExactSuspensionBoolean(t *testing.T) {
+	tests := []struct {
+		name    string
+		suspend bool
+		want    string
+	}{
+		{name: "suspend", suspend: true, want: `{"spec":{"suspend":true}}`},
+		{name: "explicit resume", suspend: false, want: `{"spec":{"suspend":false}}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var seenMethod, seenPath, seenContentType string
+			var seenBody []byte
+			httpClient := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				seenMethod = req.Method
+				seenPath = req.URL.EscapedPath()
+				seenContentType = req.Header.Get("Content-Type")
+				var err error
+				seenBody, err = io.ReadAll(req.Body)
+				require.NoError(t, err)
+				return jsonResponse(http.StatusOK, `{"metadata":{"name":"worker/one"},"spec":{"connector":"stripe","ledger":"main"}}`), nil
+			})}
+
+			_, err := New("https://stack.example/base", httpClient).PatchConnectorInstance(
+				context.Background(),
+				"worker/one",
+				ConnectorInstancePatch{"spec": map[string]any{"suspend": test.suspend}},
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, http.MethodPatch, seenMethod)
+			require.Equal(t, "/base/api/connectivity/connectorinstances/worker%2Fone", seenPath)
+			require.Equal(t, "application/merge-patch+json", seenContentType)
+			require.Equal(t, test.want, string(seenBody))
+		})
+	}
+}
+
+func TestGetConnectorInstanceDecodesDesiredSuspensionAndObservedProvenance(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusOK, `{
+			"metadata":{"name":"worker"},
+			"spec":{"connector":"stripe","ledger":"main","suspend":false,"replicas":0},
+			"status":{"suspendedBy":[
+				{"kind":"ConnectorInstance","name":"worker","field":"spec.replicas"},
+				{"kind":"Policy","name":"maintenance","field":"spec.mutate.suspend"}
+			]}
+		}`), nil
+	})}
+
+	instance, err := New("https://stack.example", httpClient).GetConnectorInstance(context.Background(), "worker")
+
+	require.NoError(t, err)
+	require.NotNil(t, instance.Spec.Suspend)
+	require.False(t, *instance.Spec.Suspend)
+	require.NotNil(t, instance.Spec.Replicas)
+	require.Equal(t, int32(0), *instance.Spec.Replicas)
+	require.Equal(t, []SuspensionSource{
+		{Kind: "ConnectorInstance", Name: "worker", Field: "spec.replicas"},
+		{Kind: "Policy", Name: "maintenance", Field: "spec.mutate.suspend"},
+	}, instance.Status.SuspendedBy)
+}
+
 func TestClientRejectsMalformedAndEmptyObjectResponses(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/connectivityclient/integration_test.go
+++ b/internal/connectivityclient/integration_test.go
@@ -145,3 +145,41 @@ func TestGivenConnectivityAPI_WhenConfigIsPatched_ThenAPIShapeIsSent(t *testing.
 	// Then the API receives spec.config verbatim and preserves the full files array.
 	require.NoError(t, err)
 }
+
+func TestGivenConnectivityAPI_WhenSuspensionIsPatched_ThenExactBooleanBodyIsSent(t *testing.T) {
+	tests := []struct {
+		name    string
+		suspend bool
+		want    string
+	}{
+		{name: "suspension", suspend: true, want: `{"spec":{"suspend":true}}`},
+		{name: "resumption", suspend: false, want: `{"spec":{"suspend":false}}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given a Connectivity server accepting ConnectorInstance merge patches.
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				require.Equal(t, http.MethodPatch, req.Method)
+				require.Equal(t, "/api/connectivity/connectorinstances/worker", req.URL.EscapedPath())
+				require.Equal(t, "application/merge-patch+json", req.Header.Get("Content-Type"))
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				require.Equal(t, test.want, string(body))
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"metadata":{"name":"worker"},"spec":{"connector":"stripe","ledger":"main"}}`)
+			}))
+			defer server.Close()
+
+			// When the client requests suspension or resumption.
+			_, err := New(server.URL, server.Client()).PatchConnectorInstance(
+				context.Background(),
+				"worker",
+				ConnectorInstancePatch{"spec": map[string]any{"suspend": test.suspend}},
+			)
+
+			// Then the exact boolean, including false, reaches the HTTP route.
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/connectivityclient/models.go
+++ b/internal/connectivityclient/models.go
@@ -134,21 +134,30 @@ type ConnectorInstanceSpec struct {
 	Ledger          string                   `json:"ledger"`
 	StartSequence   *int64                   `json:"startSequence,omitempty"`
 	PollInterval    *string                  `json:"pollInterval,omitempty"`
+	Suspend         *bool                    `json:"suspend,omitempty"`
+	Replicas        *int32                   `json:"replicas,omitempty"`
 	Config          *ConnectorInstanceConfig `json:"config,omitempty"`
 }
 
+type SuspensionSource struct {
+	Kind  string `json:"kind"`
+	Name  string `json:"name"`
+	Field string `json:"field,omitempty"`
+}
+
 type ConnectorInstanceStatus struct {
-	Phase                *string `json:"phase,omitempty"`
-	State                *string `json:"state,omitempty"`
-	ConnectorAddress     *string `json:"connectorAddress,omitempty"`
-	ResolvedImage        *string `json:"resolvedImage,omitempty"`
-	ResolvedConnectorRef *string `json:"resolvedConnectorRef,omitempty"`
-	ResolvedVersion      *string `json:"resolvedVersion,omitempty"`
-	ResolvedDigest       *string `json:"resolvedDigest,omitempty"`
-	CurrentSequence      *int64  `json:"currentSequence,omitempty"`
-	SourceTipSequence    *int64  `json:"sourceTipSequence,omitempty"`
-	LastError            *string `json:"lastError,omitempty"`
-	Message              *string `json:"message,omitempty"`
+	Phase                *string            `json:"phase,omitempty"`
+	State                *string            `json:"state,omitempty"`
+	ConnectorAddress     *string            `json:"connectorAddress,omitempty"`
+	ResolvedImage        *string            `json:"resolvedImage,omitempty"`
+	ResolvedConnectorRef *string            `json:"resolvedConnectorRef,omitempty"`
+	ResolvedVersion      *string            `json:"resolvedVersion,omitempty"`
+	ResolvedDigest       *string            `json:"resolvedDigest,omitempty"`
+	CurrentSequence      *int64             `json:"currentSequence,omitempty"`
+	SourceTipSequence    *int64             `json:"sourceTipSequence,omitempty"`
+	LastError            *string            `json:"lastError,omitempty"`
+	Message              *string            `json:"message,omitempty"`
+	SuspendedBy          []SuspensionSource `json:"suspendedBy,omitempty"`
 }
 
 type ConnectorInstance struct {


### PR DESCRIPTION
## Summary

- add connector instance suspend and unsuspend commands
- send the suspension intent only through the Connectivity API
- display suspend, replicas, phase, conditions, and suspension provenance in connector instance output
- preserve explicit false and zero values in HTTP requests

## User impact

Users can request suspension or resumption with:

    fctl connectivity connectorinstances suspend INSTANCE --confirm
    fctl connectivity connectorinstances unsuspend INSTANCE --confirm

The commands report that the request was accepted and leave convergence to the operator.

## Validation

- full fctl test suite: pass
- pre-commit and lint: pass
- internal connectivity client coverage: 91.5%
- connector instance command coverage: 85.7%
- independent review: pass with no findings

## Dependency

This PR targets feat/connectivity-cli and relies on the corresponding Connectivity API and operator suspension changes.
